### PR TITLE
Fix a few typos and rewording in reference guide

### DIFF
--- a/src/docs/histograms.adoc
+++ b/src/docs/histograms.adoc
@@ -2,7 +2,7 @@ Timers and distribution summaries can be enriched with histogram statistics that
 time series for each of a set of buckets.
 
 Histograms can be used to compute quantiles or other summary statistics in some monitoring backends
-(e.g. [Prometheus](https://prometheus.io/docs/querying/functions/#histogram_quantile)). Because histograms
+(e.g. https://prometheus.io/docs/querying/functions/#histogram_quantile[Prometheus]). Because histograms
 buckets are exposed as individual counters to the monitoring backend, it is possible to aggregate
 observations across a distributed system and compute summary statistics like quantiles for an entire
 cluster.

--- a/src/docs/index.adoc
+++ b/src/docs/index.adoc
@@ -81,7 +81,8 @@ include::logback.adoc[leveloffset=+2]
 
 == Spring integration
 
-As of Spring Boot 2.0 / Spring Framework 5.0, Micrometer
+As of Spring Boot 2.0 / Spring Framework 5.0, Micrometer is the instrumentation
+library powering the delivery of application metrics from Spring.
 
 === Web monitoring
 

--- a/src/docs/quantiles.adoc
+++ b/src/docs/quantiles.adoc
@@ -23,7 +23,7 @@ information about the nature of latency across the cluster while providing a vis
 For distribution summaries, you can use `summaryBuilder(name)` which mirrors this construction.
 
 This would result in additional gauges with tags `quantile=0.5` and `quantile=0.95`. The 0.95 quantile is the
-the value below which 95% of observations in a group of observations fall. 0.5 represents the media of our
+the value below which 95% of observations in a group of observations fall. 0.5 represents the median of our
 observations thus far.
 
 It is also possible to indicate that you want to compute quantiles in an `@Timed` annotation:

--- a/src/docs/quantiles.adoc
+++ b/src/docs/quantiles.adoc
@@ -1,4 +1,4 @@
-Timers and distribution summaries can be enriched with [quantiles](https://en.wikipedia.org/wiki/Quantile) computed in your app prior to shipping
+Timers and distribution summaries can be enriched with https://en.wikipedia.org/wiki/Quantile[quantiles] computed in your app prior to shipping
 to a monitoring backend.
 
 ```java

--- a/src/docs/timers.adoc
+++ b/src/docs/timers.adoc
@@ -33,7 +33,7 @@ public interface Timer extends Meter {
 
 ifeval::["{system}" == "atlas"]
 While reading directly from a `Timer` returns a `double`, the underlying value
-stored in Spectator is a nanosecond-precise `long`. What precision is lost by
+is stored in what is called a Spectator, as a nanosecond-precise `long`. What precision is lost by
 converting to a `double` in the `Timer` interface will not affect a system like
 Atlas, because it will be configured to read measurements from the underlying
 Spectator `Timer` that `spring-metrics` is hiding from you.


### PR DESCRIPTION
These came up while I was reading the reference guide (the default one, for Atlas).