### PR TITLE
Correct path on which the Prometheus metrics available for Spring Boot

### DIFF
--- a/src/docs/spring-configuring.adoc
+++ b/src/docs/spring-configuring.adoc
@@ -50,7 +50,7 @@ For a full list of configuration properties that can influence Atlas publishing,
 endif::[]
 
 ifeval::["{system}" == "prometheus"]
-If Spring Boot Actuator is on the classpath, an actuator endpoint will be wired to `/prometheus` by default that presents a Prometheus scrape with the appropriate format.
+If Spring Boot Actuator is on the classpath, an actuator endpoint will be wired to `/application/prometheus` by default that presents a Prometheus scrape with the appropriate format.
 
 To add actuator if it isn't already present on your classpath in Gradle:
 
@@ -80,7 +80,7 @@ Here is an example `scrape_config` to add to prometheus.yml:
 ```yml
 scrape_configs:
   - job_name: 'spring'
-    metrics_path: '/prometheus'
+    metrics_path: '/application/prometheus'
     static_configs:
       - targets: ['HOST:PORT']
 ```


### PR DESCRIPTION
As of Spring Boot 2.0.0.M4 the correct path where the Prometheus metrics
are available is `/application/prometheus`, not `/prometheus`