### PR TITLE
Metrics Binder Spring example class name

### DIFF
--- a/src/docs/spring-configuring.adoc
+++ b/src/docs/spring-configuring.adoc
@@ -115,7 +115,7 @@ To register other binders with the registry, add them as `@Bean`s to your applic
 [source,java]
 ----
 @Bean
-ThreadMetrics threadMetrics() {
-    return new ThreadMetrics();
+JvmThreadMetrics threadMetrics() {
+    return new JvmThreadMetrics();
 }
 ----


### PR DESCRIPTION
In this example of an additional metrics binder, a class named `ThreadMetrics` is referenced, but does not exist in the project. I replace it here with a reference to the class `JvmThreadMetrics`, which is a valid metrics binder in the Micrometer project.