### PR TITLE
Fix enum case for Datadog docs

### DIFF
--- a/src/docs/implementations/datadog.adoc
+++ b/src/docs/implementations/datadog.adoc
@@ -96,7 +96,7 @@ StatsdConfig config = new StatsdConfig() {
 
     @Override
     public StatsdFlavor flavor() {
-        return StatsdFlavor.Datadog;
+        return StatsdFlavor.DATADOG;
     }
 };
 


### PR DESCRIPTION
Current docs say `StatsdFlavor.Datadog` but the enum is actually `StatsdFlavor.DATADOG`