### PR TITLE
fix doc regarding Spring Boot 2 metrics properties

### DIFF
--- a/src/docs/spring/spring-web.adoc
+++ b/src/docs/spring/spring-web.adoc
@@ -7,10 +7,10 @@ Spring Boot autoconfigures interceptors to record metrics on your endpoints. By 
 [source,properties]
 ----
 # true by default
-management.metrics.export.web.auto-time-server-requests=false
+management.metrics.web.server.auto-time-requests=false
 ----
 
-If you turn off `autoTimeServerRequests`, or if you'd like to customize the timer for a particular endpoint, add `@io.micrometer.core.annotation.Timed` to:
+If you turn off `autoTimeRequests`, or if you'd like to customize the timer for a particular endpoint, add `@io.micrometer.core.annotation.Timed` to:
 
 [source,properties]
 ----
@@ -31,7 +31,7 @@ The `Timer` is registered with a name of `http.server.requests` by default. This
 [source,properties]
 ----
 # default is `http.server.requests`
-management.metrics.export.web.server-requests-name=i.want.to.be.different
+management.metrics.web.server.requests-metric-name=i.want.to.be.different
 ----
 
 The `Timer` contains a set of dimensions for every request, governed by the primary bean `WebMvcTagsProvider` registered in your application context. If you don't provide such a bean, a default implementation is selected which adds the following dimensions:
@@ -48,7 +48,7 @@ The instrumentation of any `RestTemplate` created using the auto-configured `Res
 [source,properties]
 ----
 # default is http.client.requests
-management.metrics.export.web.client-requests-name=i.want.to.be.different.again
+management.metrics.web.client.requests-metric-name=i.want.to.be.different.again
 ----
 
 The `Timer` contains a set of dimensions for every request, governed by the primary bean `RestTemplateExchangeTagsProvider` registered in your application context. If you don't provide such a bean, a default implementation is selected which adds the following dimensions:


### PR DESCRIPTION
fix auto-configure properties to match the latest as per spring-boot-actuator-autoconfigure.
For more details pls check the [actuator project reference](https://github.com/spring-projects/spring-boot/blob/1e932860c46350bd8245559965a6922ec5ede8b2/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc)