### PR TITLE
Added escaping for configuration parameters

### DIFF
--- a/src/docs/spring/spring-web.adoc
+++ b/src/docs/spring/spring-web.adoc
@@ -34,9 +34,9 @@ The preferred way to add percentiles, percentile histograms, and SLA boundaries 
 [source,yml]
 ----
 management.metrics.distribution:
-    percentiles.http.server.requests: 0.95, 0.99
-    percentiles-histogram.http.server.requests: true <1>
-    sla.http.server.requests: 10ms, 100ms
+    percentiles[http.server.requests]: 0.95, 0.99
+    percentiles-histogram[http.server.requests]: true <1>
+    sla[http.server.requests]: 10ms, 100ms
 ----
 <1> If percentile approximations based on histograms are supported by your monitoring system, prefer this _instead_ of the `percentiles` option.
 


### PR DESCRIPTION
As far as I could see, this documentation is only used for Spring Boot versions lower than 1.5, right? If so, then I suggest this change, since in Spring Boot 1.5 it's required to escape the `http.server.request` configuration keys using brackets.