### PR TITLE
Polish Prometheus sample

### DIFF
--- a/src/docs/implementations/prometheus.adoc
+++ b/src/docs/implementations/prometheus.adoc
@@ -22,13 +22,13 @@ try {
     HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
     server.createContext("/prometheus", httpExchange -> {
         String response = prometheusRegistry.scrape(); <1>
-        httpExchange.sendResponseHeaders(200, response.length());
-        OutputStream os = httpExchange.getResponseBody();
-        os.write(response.getBytes());
-        os.close();
+        httpExchange.sendResponseHeaders(200, response.getBytes().length);
+        try (OutputStream os = httpExchange.getResponseBody()) {
+            os.write(response.getBytes());
+        }
     });
 
-    new Thread(server::start).run();
+    new Thread(server::start).start();
 } catch (IOException e) {
     throw new RuntimeException(e);
 }


### PR DESCRIPTION
This commit polishes by:

- Passing length in bytes for the second parameter to `sendResponseHeaders()` to comply its Javadoc
- Using try-resources for simplicity
- Using `Thread.start()` to trigger a new thread