### PR TITLE
Fix a section title level warning

### DIFF
--- a/src/docs/spring/spring-meter-filters.adoc
+++ b/src/docs/spring/spring-meter-filters.adoc
@@ -10,7 +10,7 @@ public MeterFilter renameRegionTagMeterFilter() {
 }
 ----
 
-=== Per-meter properties
+== Per-meter properties
 In addition to `MeterFilter` beans, it's also possible to apply a limited set of customization on a per-meter basis using properties. Per-meter customizations apply to any all meter IDs that start with the given name. For example, the following will disable any meters that have an ID starting with `example.remote`
 
 [source,properties]


### PR DESCRIPTION
This PR fixes a section title level warning as follows:

```
Error during rendering index.adoc
asciidoctor: WARNING: spring-meter-filters.adoc: line 13: section title out of sequence: expected level 2, got level 3
```