### PR TITLE
Add a "configuration" section to the JMX documentation

### DIFF
--- a/src/docs/implementations/jmx.adoc
+++ b/src/docs/implementations/jmx.adoc
@@ -29,17 +29,6 @@ counter.increment();
 
 ----
 
-These values can be exposed to Prometheus using the https://github.com/prometheus/jmx_exporter[JMX Exporter].
-
-An example Prometheus rule to translate the counter above might look like this:
-
-----
-rules:
-  - pattern: metrics<name=appCounterExampleTick.level.normal><>Count
-    name: app_counter_example_tick_normal_totals
-    type: COUNTER
-----
-
 == Counters
 
 JMX counters measure mean throughput and one-, five-, and fifteen-minute exponentially-weighted moving average throughputs.

--- a/src/docs/implementations/jmx.adoc
+++ b/src/docs/implementations/jmx.adoc
@@ -12,6 +12,34 @@ Micrometer also sometimes scrapes data from JMX beans for use in reporting metri
 
 include::hierarchical-name-mapping.adoc[]
 
+== Configuring
+
+The example below uses a `JmxMeterRegistry` to set values into JMX beans.
+
+[source,java]
+----
+
+meterRegistry = new JmxMeterRegistry(JmxConfig.DEFAULT, Clock.SYSTEM);
+counter = Counter.builder("app.counter.example.tick")
+        .tags("level", "normal")
+        .description("Number of info level events that made it to the logs")
+        .register(meterRegistry);
+
+counter.increment();
+
+----
+
+These values can be exposed to Prometheus using the https://github.com/prometheus/jmx_exporter[JMX Exporter].
+
+An example Prometheus rule to translate the counter above might look like this:
+
+----
+rules:
+  - pattern: metrics<name=appCounterExampleTick.level.normal><>Count
+    name: app_counter_example_tick_normal_totals
+    type: COUNTER
+----
+
 == Counters
 
 JMX counters measure mean throughput and one-, five-, and fifteen-minute exponentially-weighted moving average throughputs.


### PR DESCRIPTION
This adds an example of how to put use the JMX registry. This may not be the best example, so I'm open to suggestions.