### PR TITLE
Polish

### DIFF
--- a/src/docs/concepts/timers.adoc
+++ b/src/docs/concepts/timers.adoc
@@ -92,7 +92,7 @@ registry.more().timer("cache.gets.latency", Tags.of("name", cache.getName()), ca
 );
 -----
 
-1. `getOperationCount()` is a monotonically increasing function incrementing with every cache get from the beginning of its life.
+1. `getGetOperationCount()` is a monotonically increasing function incrementing with every cache get from the beginning of its life.
 2. This represents the unit of time represented by `getTotalGetLatency()`. Each registry implementation specifies what its expected base unit of time is, and the total time reported will be scaled to this value.
 
 The function-tracking timer, in concert with the monitoring system's rate normalizing functionality (whether this is an artifact of the query language or the way data is pushed to the system), adds a layer of richness on top of the cumulative value of the functions themselves. You can reason about the _rate_ of throughput and latency, whether that rate is within an acceptable bound, is increasing or decreasing over time, etc.

--- a/src/docs/implementations/datadog.adoc
+++ b/src/docs/implementations/datadog.adoc
@@ -4,7 +4,7 @@ Jon Schneider <jschneider@pivotal.io>
 :sectnums:
 :system: atlas
 
-Datadog is a dimensional time-series SAAS with built-in dashboarding and alerting.
+Datadog is a dimensional time-series SaaS with built-in dashboarding and alerting.
 
 == Installation and Configuration
 

--- a/src/docs/implementations/graphite.adoc
+++ b/src/docs/implementations/graphite.adoc
@@ -4,7 +4,7 @@ Jon Schneider <jschneider@pivotal.io>
 :sectnums:
 :system: graphite
 
-Graphite is one of the most popular current hierarchical metrics systems backed by a fixed-size database, similar in design and purpose to RRD. It originated at Orbitz in 2006 and was open sourced in 2008.
+Graphite is one of the most popular current hierarchical metrics systems backed by a fixed-size database, similar in design and purpose to RRDtool. It originated at Orbitz in 2006 and was open sourced in 2008.
 
 include::install.adoc[]
 
@@ -24,7 +24,7 @@ GraphiteConfig graphiteConfig = new GraphiteConfig() {
     }
 };
 
-MeterRegistry registry = new GraphiteMeterRegistry(graphiteConfig, HierarchicalNameMapper.DEFAULT, Clock.SYSTEM);
+MeterRegistry registry = new GraphiteMeterRegistry(graphiteConfig, Clock.SYSTEM, HierarchicalNameMapper.DEFAULT);
 ----
 
 Micrometer uses Dropwizard Metrics as the underlying instrumentation library when recording metrics destined for Graphite. `GraphiteConfig` is an interface with a set of default methods. If, in the implementation of `get(String k)`, rather than returning `null`, you  instead bind it to a property source, you can override the default configuration. For example, Micrometer's Spring Boot support binds properties prefixed with `management.metrics.export.graphite` directly to the `GraphiteConfig`:
@@ -46,9 +46,9 @@ include::hierarchical-name-mapping.adoc[]
 
 == Prefixing your metrics
 
-To add a prefix to all metrics going to graphite, use the `GraphiteConfig#tagsAsPrefix` configuration option. This option applies the tag value of a set of common tags as a prefix. For example, if `tagsAsPrefix` contains "application", if a meter is created with a tag "application=APPNAME", it will appear in Graphite as "APPNAME.myTimer".
+To add a prefix to all metrics going to graphite, use the `GraphiteConfig#tagsAsPrefix` configuration option. This option applies the tag value of a set of common tags as a prefix. For example, if `tagsAsPrefix` contains "application", and a meter named "myTimer" is created with a tag "application=APPNAME", it will appear in Graphite as "APPNAME.myTimer".
 
-Generally, when using `tagsAsPrefix` add a common tag to the registry so that the tag is present on all meters belonging to that registry:
+Generally, when using `tagsAsPrefix`, add common tags to the registry so that the tags are present on all meters belonging to that registry:
 
 [source,java]
 ----
@@ -69,8 +69,8 @@ To meet your specific naming needs, you can also provide a custom hierarchical n
 ----
 GraphiteMeterRegistry r = new GraphiteMeterRegistry(
             GraphiteConfig.DEFAULT,
-            (id, convention) -> "prefix." + HierarchicalNameMapper.DEFAULT.toHierarchicalName(id, convention),
-            Clock.SYSTEM);
+            Clock.SYSTEM,
+            (id, convention) -> "prefix." + HierarchicalNameMapper.DEFAULT.toHierarchicalName(id, convention));
 ----
 
 == Further customizing the `GraphiteReporter`

--- a/src/docs/implementations/hierarchical-name-mapping.adoc
+++ b/src/docs/implementations/hierarchical-name-mapping.adoc
@@ -2,6 +2,6 @@
 
 Micrometer provides a `HierarchicalNameMapper` interface that governs how a dimensional meter id is mapped to flat hierarchical names.
 
-The default (`HierarchicalNameMapper.DEFAULT`) sort tags alphabetically by key and appends tag key values to the base meter name with '.', e.g. `http_server_requests.response.200.method.GET`. The name and tag keys have the registry's naming convention applied to them first.
+The default (`HierarchicalNameMapper.DEFAULT`) sorts tags alphabetically by key and appends tag key/value pairs to the base meter name with '.', e.g. `http_server_requests.method.GET.response.200`. The name and tag keys have the registry's naming convention applied to them first.
 
-If there is something special about your naming scheme that you need to honor, you can provide your own `HierarchicalNameMapper` implementation. The most common cause of a custom mapper comes from a need to prefix something to the front of every metric (generally something like `app.<name>.http_server_requests.response.200.method.GET`.
+If there is something special about your naming scheme that you need to honor, you can provide your own `HierarchicalNameMapper` implementation. The most common cause of a custom mapper comes from a need to prefix something to the front of every metric (generally something like `app.<name>.http_server_requests.method.GET.response.200`).


### PR DESCRIPTION
This PR fixes some typos and polishes trivial stuff. Especially:

- Fix the order for `GraphiteMeterRegistry` constructor parameters as it doesn't match with [the current implementation](https://github.com/micrometer-metrics/micrometer/blob/302ad0f6fdf0191eaf5a2a96d7bef517b1a4067d/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteMeterRegistry.java#L38).
- Fix the order for tags in `http_server_requests.response.200.method.GET` as they weren't ordered properly.