### PR TITLE
Document custom HierarchicalNameMapper ignores tagsAsPrefix

### DIFF
--- a/src/docs/implementations/graphite.adoc
+++ b/src/docs/implementations/graphite.adoc
@@ -73,6 +73,8 @@ GraphiteMeterRegistry r = new GraphiteMeterRegistry(
             (id, convention) -> "prefix." + HierarchicalNameMapper.DEFAULT.toHierarchicalName(id, convention));
 ----
 
+NOTE: If you use a custom `HierarchicalNameMapper`, `tagsAsPrefix` will be ignored.
+
 == Further customizing the `GraphiteReporter`
 
 We give you the option to configure `GraphiteReporter` yourself if you need further customization. Just use this constructor and provide your own `GraphiteReporter`:


### PR DESCRIPTION
This PR documents that a custom `HierarchicalNameMapper` will make `tagsAsPrefix` be ignored for Graphite.

Closes gh-41