### PR TITLE
Document how to disable Spring Boot Actuator metrics support

### DIFF
--- a/src/docs/spring/index.adoc
+++ b/src/docs/spring/index.adoc
@@ -72,6 +72,10 @@ the Spring-managed `MeterRegistry`.
 
 include::spring-meter-filters.adoc[leveloffset=+1]
 
+== With Spring Boot Actuator
+
+include::spring-boot-actuator.adoc[leveloffset=+1]
+
 == Application properties
 
 include::spring-boot-application-properties.adoc[leveloffset=+1]

--- a/src/docs/spring/spring-boot-actuator.adoc
+++ b/src/docs/spring/spring-boot-actuator.adoc
@@ -1,0 +1,16 @@
+Spring Boot Actuator provides its own metrics support and it's not interacting with Micrometer at all. So the metrics collections happen independently.
+
+If you want to disable the metrics support from Spring Boot Actuator, add the following properties:
+
+[source,properties]
+----
+spring.autoconfigure.exclude=\
+org.springframework.boot.actuate.autoconfigure.MetricFilterAutoConfiguration,\
+org.springframework.boot.actuate.autoconfigure.MetricRepositoryAutoConfiguration,\
+org.springframework.boot.actuate.autoconfigure.MetricsDropwizardAutoConfiguration,\
+org.springframework.boot.actuate.autoconfigure.MetricsChannelAutoConfiguration,\
+org.springframework.boot.actuate.autoconfigure.MetricExportAutoConfiguration,\
+org.springframework.boot.actuate.autoconfigure.PublicMetricsAutoConfiguration
+
+endpoints.metrics.enabled=false
+----


### PR DESCRIPTION
This PR documents how to disable Spring Boot Actuator metrics support.

Closes gh-59