### PR TITLE
Document OkHttpClient instrumentation

### DIFF
--- a/src/components/DocRoot/index.js
+++ b/src/components/DocRoot/index.js
@@ -113,6 +113,8 @@ export default function DocRoot() {
             <li><NavLink className="doc-section" to="/docs/ref/cache">Cache</NavLink>. Instrumentation for the most
               popular caching frameworks.
             </li>
+            <li><NavLink className="doc-section" to="/docs/ref/okhttpclient">OkHttpClient</NavLink>. Instrumentation for OkHttpClient.
+            </li>
           </ul>
         </li>
         <li><span className="doc-section">Guides</span>.

--- a/src/components/DocRoutes/index.js
+++ b/src/components/DocRoutes/index.js
@@ -10,6 +10,7 @@ let docsSpring = require('!asciidoc-loader!../../docs/spring/index.adoc');
 let docsConcepts = require('!asciidoc-loader!../../docs/concepts/index.adoc');
 let docsJvm = require('!asciidoc-loader!../../docs/jvm/index.adoc');
 let docsCache = require('!asciidoc-loader!../../docs/cache/index.adoc');
+let docsOkHttpClient = require('!asciidoc-loader!../../docs/okhttpclient/index.adoc');
 let docsConsoleReporter = require('!asciidoc-loader!../../docs/guide/console-reporter.adoc');
 let docsHealthCheck = require('!asciidoc-loader!../../docs/guide/health-check.adoc');
 
@@ -46,6 +47,10 @@ export default function DocRoutes() {
 
       <Route path="/docs/ref/cache" render={() =>
         <DocSection title="Cache Metrics" content={docsCache}/>
+      }/>
+
+      <Route path="/docs/ref/okhttpclient" render={() =>
+        <DocSection title="OkHttpClient Metrics" content={docsOkHttpClient}/>
       }/>
 
       <Route path="/docs/guide/consoleReporter" render={() =>

--- a/src/docs/okhttpclient/index.adoc
+++ b/src/docs/okhttpclient/index.adoc
@@ -27,4 +27,4 @@ OkHttpClient client = new OkHttpClient.Builder()
     .build();
 ----
 
-But note that the sample might trigger tag cardinality explosion as a URI path itself is being used for tag values.
+WARNING: The sample might trigger tag cardinality explosion as a URI path itself is being used for tag values.

--- a/src/docs/okhttpclient/index.adoc
+++ b/src/docs/okhttpclient/index.adoc
@@ -1,0 +1,30 @@
+Micrometer supports binding metrics to `OkHttpClient` via `EventListener`.
+
+You can collect metrics from `OkHttpClient` by adding `OkHttpMetricsEventListener` as follows:
+
+[source,java]
+----
+OkHttpClient client = new OkHttpClient.Builder()
+    .eventListener(OkHttpMetricsEventListener.builder(registry, "okhttp.requests")
+        .tags(Tags.of("foo", "bar"))
+        .build())
+    .build();
+----
+
+NOTE: `uri` tag is usually limited to URI patterns to mitigate tag cardinality explosion but `OkHttpClient` doesn't
+provide URI patterns. We provide `URI_PATTERN` header to support `uri` tag or you can configure a URI mapper to provide
+your own tag values for `uri` tag.
+
+To configure a URI mapper, you can use `uriMapper()` as follows:
+
+[source,java]
+----
+OkHttpClient client = new OkHttpClient.Builder()
+    .eventListener(OkHttpMetricsEventListener.builder(registry, "okhttp.requests")
+        .uriMapper(req -> req.url().encodedPath())
+        .tags(Tags.of("foo", "bar"))
+        .build())
+    .build();
+----
+
+But note that the sample might trigger tag cardinality explosion as a URI path itself is being used for tag values.


### PR DESCRIPTION
This PR documents `OkHttpClient` instrumentation and focuses on documenting the `URI_PATTERN` header.

Closes gh-64