### PR TITLE
Prefer lowercase dot notation naming

### DIFF
--- a/src/docs/concepts/naming.adoc
+++ b/src/docs/concepts/naming.adoc
@@ -1,4 +1,4 @@
-Micrometer employs a naming convention that separates words with '.' (dot). Because different monitoring systems have different recommendations regarding naming convention, and some naming conventions may actually be breaking for one system and not another, each Micrometer implementation for a monitor system packs with a naming convention that transforms dot notation names to the recommended naming convention. Additionally, this naming convention implementation sanitizes names and tags of special characters that are disallowed by the monitoring system they are designed for. You can override the default naming convention for a registry if you'd like by implementing `NamingConvention` and setting it on the registry with:
+Micrometer employs a naming convention that separates lowercase words with a '.' (dot) character. Different monitoring systems have different recommendations regarding naming convention, and some naming conventions may actually be breaking for one system and not another. Each Micrometer implementation for a monitor system packs with a naming convention that transforms lowercase dot notation names to the recommended naming convention. Additionally, this naming convention implementation sanitizes names and tags of special characters that are disallowed by the monitoring system they are designed for. You can override the default naming convention for a registry if you'd like by implementing `NamingConvention` and setting it on the registry with:
 
 [source,java]
 ----
@@ -17,9 +17,11 @@ registry.timer("http.server.requests");
 3. Graphite - `http.server.requests`
 4. InfluxDB - `http_server_requests`
 
-By adhering to Micrometer's dot notation convention, you guarantee the maximum degree of portability for your metric names across monitoring systems.
+By adhering to Micrometer's lowercase dot notation convention, you guarantee the maximum degree of portability for your metric names across monitoring systems.
 
 == Tag naming
+
+It is recommended to follow the same lowercase dot notation described for meter names when naming tags. Utilizing this consistent naming convention for tags allows for better translation into the respective monitoring system's idiomatic naming schemes.
 
 Suppose we are trying to measure the number of http requests and the number of database calls.
 


### PR DESCRIPTION
Updating naming doc to prefer lowercase dot notation for the naming of meters and tags.