### PR TITLE
URL Cleanup

### DIFF
--- a/src/docs/concepts/timers.adoc
+++ b/src/docs/concepts/timers.adoc
@@ -116,7 +116,7 @@ FunctionTimer.builder("cache.gets.latency", cache,
 
 == Pause detection
 
-Micrometer uses the LatencyUtils package to compensate for http://highscalability.com/blog/2015/10/5/your-load-generator-is-probably-lying-to-you-take-the-red-pi.html[coordinated omission] -- extra latency arising from system and VM pauses that skew your latency statistics downward. Distribution statistics like percentiles and SLA counts are influenced by a pause detector implementation that adds additional latency here and there to compensate for pauses.
+Micrometer uses the LatencyUtils package to compensate for https://highscalability.com/blog/2015/10/5/your-load-generator-is-probably-lying-to-you-take-the-red-pi.html[coordinated omission] -- extra latency arising from system and VM pauses that skew your latency statistics downward. Distribution statistics like percentiles and SLA counts are influenced by a pause detector implementation that adds additional latency here and there to compensate for pauses.
 
 Micrometer supports two pause detector implementations: a clock-drift based detector and a NOOP detector. By default Micrometer configures a clock-drift detector in order to report as-accurate-as-possible metrics without further configuration.
 

--- a/src/docs/implementations/kairos.adoc
+++ b/src/docs/implementations/kairos.adoc
@@ -4,7 +4,7 @@ Jon Schneider <jschneider@pivotal.io>
 :sectnums:
 :system: kairos
 
-KairosDB is a dimensional time-series database built on top of Cassandra. Charting can be accomplished in Grafana via a link:http://docs.grafana.org/v4.0/datasources/kairosdb/[Kairos datasource].
+KairosDB is a dimensional time-series database built on top of Cassandra. Charting can be accomplished in Grafana via a link:https://docs.grafana.org/v4.0/datasources/kairosdb/[Kairos datasource].
 
 include::install.adoc[]
 

--- a/src/img/logo-no-title.svg
+++ b/src/img/logo-no-title.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<!-- Created with Inkscape (https://www.inkscape.org/) -->
 
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="https://creativecommons.org/ns#"
+   xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:inkscape="https://www.inkscape.org/namespaces/inkscape"
    id="svg3355"
    version="1.1"
    inkscape:version="0.91 r13725"
@@ -19,7 +19,7 @@
    sodipodi:docname="logo-no-title.svg"><metadata
      id="metadata3361"><rdf:RDF><cc:Work
          rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+           rdf:resource="https://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
      id="defs3359"><clipPath
        clipPathUnits="userSpaceOnUse"
        id="clipPath3369"><path

--- a/src/img/logo.svg
+++ b/src/img/logo.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<!-- Created with Inkscape (https://www.inkscape.org/) -->
 
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="https://creativecommons.org/ns#"
+   xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:inkscape="https://www.inkscape.org/namespaces/inkscape"
    id="svg3355"
    version="1.1"
    inkscape:version="0.91 r13725"
@@ -19,7 +19,7 @@
    sodipodi:docname="logo.svg"><metadata
      id="metadata3361"><rdf:RDF><cc:Work
          rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+           rdf:resource="https://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
      id="defs3359"><clipPath
        clipPathUnits="userSpaceOnUse"
        id="clipPath3369"><path


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://slack.micrometer.io (200) with 2 occurrences could not be migrated:  
   ([https](https://slack.micrometer.io) result SSLHandshakeException).
* http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd (404) with 2 occurrences could not be migrated:  
   ([https](https://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd) result AnnotatedConnectException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://creativecommons.org/ns with 2 occurrences migrated to:  
  https://creativecommons.org/ns ([https](https://creativecommons.org/ns) result 200).
* http://www.w3.org/1999/02/22-rdf-syntax-ns with 2 occurrences migrated to:  
  https://www.w3.org/1999/02/22-rdf-syntax-ns ([https](https://www.w3.org/1999/02/22-rdf-syntax-ns) result 200).
* http://docs.grafana.org/v4.0/datasources/kairosdb/ with 1 occurrences migrated to:  
  https://docs.grafana.org/v4.0/datasources/kairosdb/ ([https](https://docs.grafana.org/v4.0/datasources/kairosdb/) result 301).
* http://www.inkscape.org/ with 2 occurrences migrated to:  
  https://www.inkscape.org/ ([https](https://www.inkscape.org/) result 301).
* http://www.inkscape.org/namespaces/inkscape with 2 occurrences migrated to:  
  https://www.inkscape.org/namespaces/inkscape ([https](https://www.inkscape.org/namespaces/inkscape) result 301).
* http://highscalability.com/blog/2015/10/5/your-load-generator-is-probably-lying-to-you-take-the-red-pi.html with 1 occurrences migrated to:  
  https://highscalability.com/blog/2015/10/5/your-load-generator-is-probably-lying-to-you-take-the-red-pi.html ([https](https://highscalability.com/blog/2015/10/5/your-load-generator-is-probably-lying-to-you-take-the-red-pi.html) result 302).
* http://purl.org/dc/dcmitype/StillImage with 2 occurrences migrated to:  
  https://purl.org/dc/dcmitype/StillImage ([https](https://purl.org/dc/dcmitype/StillImage) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:7101/api/v1/publish with 3 occurrences
* http://localhost:7101/lwc/api/v1/evaluate with 1 occurrences
* http://localhost:7101/lwc/api/v1/expressions/local-dev with 1 occurrences
* http://localhost:8086 with 3 occurrences
* http://purl.org/dc/elements/1.1/ with 2 occurrences
* http://www.w3.org/1999/xhtml with 2 occurrences
* http://www.w3.org/2000/svg with 4 occurrences