### PR TITLE
Document on HttpSender with Resilience4j retry

### DIFF
--- a/src/components/DocRoot/index.js
+++ b/src/components/DocRoot/index.js
@@ -147,6 +147,9 @@ export default function DocRoot() {
           <ul>
             <li><NavLink className="doc-section" to="/docs/guide/healthAsGauge">Mapping Spring's health indicators to metrics</NavLink></li>
           </ul>
+          <ul>
+            <li><NavLink className="doc-section" to="/docs/guide/httpSenderResilience4jRetry">HttpSender with Resilience4j retry</NavLink></li>
+          </ul>
         </li>
       </ol>
     </div>

--- a/src/components/DocRoutes/index.js
+++ b/src/components/DocRoutes/index.js
@@ -13,6 +13,7 @@ let docsCache = require('!asciidoc-loader!../../docs/cache/index.adoc');
 let docsOkHttpClient = require('!asciidoc-loader!../../docs/okhttpclient/index.adoc');
 let docsConsoleReporter = require('!asciidoc-loader!../../docs/guide/console-reporter.adoc');
 let docsHealthCheck = require('!asciidoc-loader!../../docs/guide/health-check.adoc');
+let docsHttpSenderResilience4jRetry = require('!asciidoc-loader!../../docs/guide/http-sender-resilience4j-retry.adoc');
 
 const systems = ['appOptics', 'atlas', 'azure-monitor', 'datadog', 'dynatrace', 'elastic', 'ganglia', 'graphite', 'humio', 'influx', 'jmx', 'kairos', 'new-relic', 'prometheus', 'signalFx', 'statsD', 'wavefront'];
 
@@ -59,6 +60,10 @@ export default function DocRoutes() {
 
       <Route path="/docs/guide/healthAsGauge" render={() =>
         <DocSection title="Mapping Spring's health indicators to metrics" content={docsHealthCheck}/>
+      }/>
+
+      <Route path="/docs/guide/httpSenderResilience4jRetry" render={() =>
+        <DocSection title="HttpSender with Resilience4j retry" content={docsHttpSenderResilience4jRetry}/>
       }/>
     </div>
   )

--- a/src/docs/guide/http-sender-resilience4j-retry.adoc
+++ b/src/docs/guide/http-sender-resilience4j-retry.adoc
@@ -1,0 +1,40 @@
+= HttpSender with Resilience4j retry
+
+`HttpSender` is an interface for HTTP client which is used in meter registries for HTTP-based metrics publication. There
+are three implementations as follows:
+
+* `HttpUrlConnectionSender`: `HttpURLConnection`-based `HttpSender`
+* `OkHttpSender`: OkHttp-based `HttpSender`
+* `ReactorNettySender`: Reactor Netty-based `HttpSender`
+
+There's no out-of-the-box support for retry but you can decorate it with Resilience4j retry as follows:
+
+[source,java]
+----
+	@Bean
+	public DatadogMeterRegistry datadogMeterRegistry(DatadogConfig datadogConfig, Clock clock) {
+		return DatadogMeterRegistry.builder(datadogConfig)
+				.clock(clock)
+				.httpClient(new RetryHttpClient())
+				.build();
+	}
+
+	private static class RetryHttpClient extends HttpUrlConnectionSender {
+
+		private final RetryConfig retryConfig = RetryConfig.custom()
+				.maxAttempts(2)
+				.waitDuration(Duration.ofSeconds(5))
+				.build();
+
+		private final Retry retry = Retry.of("datadog-metrics", this.retryConfig);
+
+		@Override
+		public Response send(Request request) {
+			CheckedFunction0<Response> retryableSupplier = Retry.decorateCheckedSupplier(
+					this.retry,
+					() -> super.send(request));
+			return Try.of(retryableSupplier).get();
+		}
+
+	}
+----


### PR DESCRIPTION
This PR documents on `HttpSender` with Resilience4j retry.