### PR TITLE
Fix favicon size in manifest.json

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "icons": [
     {
       "src": "favicon.ico",
-      "sizes": "192x192",
+      "sizes": "16x16",
       "type": "image/png"
     }
   ],


### PR DESCRIPTION
This PR fixes favicon size in `manifest.json` as the following error occurs on Console in Chrome:

```
Error while trying to use the following icon from the Manifest: https://micrometer.io/favicon.ico (Resource size is not correct - typo in the Manifest?)
```