### PR TITLE
Document meter binder for ExecutorService

### DIFF
--- a/src/docs/jvm/index.adoc
+++ b/src/docs/jvm/index.adoc
@@ -13,3 +13,27 @@ new JvmThreadMetrics().bindTo(registry); <5>
 <3> Gauges max and live data size, promotion and allocation rates, and times GC pauses (or concurrent phase time in the case of CMS).
 <4> Gauges current CPU total and load average.
 <5> Gauges thread peak, number of daemon threads, and live threads.
+
+Micrometer also provides a meter binder for `ExecutorService`. You can instrument your `ExecutorService` as follows:
+
+[source, java]
+----
+new ExecutorServiceMetrics(executor, executorServiceName, tags).bindTo(registry);
+----
+
+Metrics created from the binder vary based on the type of `ExecutorService`.
+
+For `ThreadPoolExecutor`, the following metrics are provided:
+
+- `executor.completed` (`FunctionCounter`): The approximate total number of tasks that have completed execution.
+- `executor.active` (`Gauge`): The approximate number of threads that are actively executing tasks.
+- `executor.queued` (`Gauge`): The approximate number of tasks that are queued for execution.
+- `executor.pool.size` (`Gauge`): The current number of threads in the pool.
+
+For `ForkJoinPool`, the following metrics are provided:
+
+- `executor.steals` (`FunctionCounter`): Estimate of the total number of tasks stolen from one thread's work queue by
+another. The reported value underestimates the actual total number of steals when the pool is not quiescent.
+- `executor.queued` (`Gauge`): An estimate of the total number of tasks currently held in queues by worker threads.
+- `executor.active` (`Gauge`): An estimate of the number of threads that are currently stealing or executing tasks.
+- `executor.running` (`Gauge`): An estimate of the number of worker threads that are not blocked waiting to join tasks or for other managed synchronization threads.


### PR DESCRIPTION
This PR documents meter binder for `ExecutorService`.

Closes #97 