### PR TITLE
Clarify 'any arbitrary method' in TimedAspect documentation

### DIFF
--- a/src/docs/concepts/timers.adoc
+++ b/src/docs/concepts/timers.adoc
@@ -76,7 +76,7 @@ public class TimedConfiguration {
 }
 ```
 
-Applying `TimedAspect` makes `@Timed` usable on any arbitrary method.
+Applying `TimedAspect` makes `@Timed` usable on any arbitrary method in an AspectJ proxied instance.
 
 == Function-tracking timers
 


### PR DESCRIPTION
This PR changes to clarify 'any arbitrary method' in `TimedAspect` documentation.

Closes gh-103