### PR TITLE
Updating Humio docs to reflect 1.3 changes

### DIFF
--- a/src/docs/implementations/humio.adoc
+++ b/src/docs/implementations/humio.adoc
@@ -42,8 +42,8 @@ management.metrics.export.humio:
     # The interval at which metrics are sent to Humio. The default is 1 minute.
     step: 1m
 
-    # The repository Micrometer will send metrics to. "sandbox" is the default, which is always the repository name of the trial/free tier on Humio.
-    repository: sandbox
+    # The cluster Micrometer will send metrics to. The default is "https://cloud.humio.com"
+    uri: https://myhumiohost
 ----
 
 == Graphing
@@ -52,7 +52,7 @@ This section serves as a quickstart to rendering useful representations in Humio
 
 === Timers
 
-The Humio implementation of `Timer` produces three fields in Humio:
+The Humio implementation of `Timer` produces four fields in Humio:
 
 1. `sum` - Rate of calls per second.
 2. `count` - Rate of total time per second.
@@ -64,8 +64,7 @@ The following query constructs a dimensionally aggregable average latency per UR
 [source, text]
 ----
 name = http_server_requests
-| eval(aggAvg=sum/count)
-| timechart(uri, function=[max(aggAvg)])
+| timechart(uri, function=max(avg))
 ----
 
 .Timer over a simulated service.


### PR DESCRIPTION
In 1.3 we deprecated the `repository` parameter, see micrometer-metrics/micrometer#1544

Corrected the example query, as it already had an `avg` field. Output is the same as before so no need to update screenshot.