### PR TITLE
Update doc on max for StepDistributionSummary and StepTimer

### DIFF
--- a/src/docs/concepts/distribution-summaries.adoc
+++ b/src/docs/concepts/distribution-summaries.adoc
@@ -23,10 +23,11 @@ DistributionSummary summary = DistributionSummary
 1. Add base units for maximum portability -- base units are part of the naming convention for some monitoring systems. Leaving it off and violating the naming convention will have no adverse effect if you forget.
 2. Optionally, you may provide a scaling factor that each recorded sample will be multiplied by as it is recorded.
 
-NOTE: Max for basic `DistributionSummary` implementations such as `CumulativeDistributionSummary`, `StepDistributionSummary` is a time window max (`TimeWindowMax`).
+NOTE: `CumulativeDistributionSummary` uses a time window max (`TimeWindowMax`).
 It means that its value is the maximum value during a time window.
 If no new values are recorded for the time window length, the max will be reset to 0 as a new time window starts.
 Time window size will be the step size of the meter registry unless expiry in `DistributionStatisticConfig` is set to other value explicitly.
+`StepDistributionSummary` also used a time window max prior to 1.4.0, but since 1.4.0, it has been changed to use a last completed step max.
 
 == Scaling and histograms
 

--- a/src/docs/concepts/timers.adoc
+++ b/src/docs/concepts/timers.adoc
@@ -25,10 +25,11 @@ Timer timer = Timer
     .register(registry);
 ----
 
-NOTE: Max for basic `Timer` implementations such as `CumulativeTimer`, `StepTimer` is a time window max (`TimeWindowMax`).
+NOTE: `CumulativeTimer` uses a time window max (`TimeWindowMax`).
 It means that its value is the maximum value during a time window.
 If no new values are recorded for the time window length, the max will be reset to 0 as a new time window starts.
 Time window size will be the step size of the meter registry unless expiry in `DistributionStatisticConfig` is set to other value explicitly.
+`StepTimer` also used a time window max prior to 1.4.0, but since 1.4.0, it has been changed to use a last completed step max.
 
 == Recording blocks of code
 


### PR DESCRIPTION
This PR updates doc on max for `StepDistributionSummary` and `StepTimer` to reflect the changes made in https://github.com/micrometer-metrics/micrometer/issues/1796 and https://github.com/micrometer-metrics/micrometer/pull/1893.