### PR TITLE
Update copyright 2017 - 2020

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -4,7 +4,7 @@ export default function Footer() {
   return (
     <div className="bg-dark text-center">
       <div className="col-12" style={{padding: 10, color: 'white'}}>
-        <p>© 2017 Pivotal Software, Inc. All Rights Reserved. See <a href="https://www.pivotal.io/terms-of-use">Terms of Use</a> and <a href="https://www.pivotal.io/privacy-policy">Privacy Policy</a>.</p>
+        <p>© 2017 - 2020 Pivotal Software, Inc. All Rights Reserved. See <a href="https://www.pivotal.io/terms-of-use">Terms of Use</a> and <a href="https://www.pivotal.io/privacy-policy">Privacy Policy</a>.</p>
       </div>
     </div>
   )


### PR DESCRIPTION
Please update the footer. It gives the impression of a dead website (or project) if the copyright notice on the landing page is already 3 years past its expiration date.