### PR TITLE
Document CloudWatch registry

### DIFF
--- a/src/components/DocRoot/index.js
+++ b/src/components/DocRoot/index.js
@@ -43,6 +43,10 @@ export default function DocRoot() {
               solution.
             </li>
 
+            <li><NavLink className="doc-section" to="/docs/registry/cloudwatch">CloudWatch</NavLink>. CloudWatch 
+              is a dimensional time-series SaaS on Amazon's cloud.
+            </li>
+
             <li><NavLink className="doc-section" to="/docs/registry/datadog">Datadog</NavLink>. Datadog
               is a dimensional time-series SAAS with built-in dashboarding and alerting. Micrometer supports shipping
               metrics to Datadog directly via its API or through Dogstatsd via the StatsD registry.

--- a/src/components/DocRoutes/index.js
+++ b/src/components/DocRoutes/index.js
@@ -16,7 +16,7 @@ let docsHttpSenderResilience4jRetry = require('!asciidoc-loader!../../docs/guide
 let docsCustomMeterRegistry = require('!asciidoc-loader!../../docs/guide/custom-meter-registry.adoc');
 let docsSupport = require('!asciidoc-loader!../../docs/support/index.adoc');
 
-const systems = ['appOptics', 'atlas', 'azure-monitor', 'datadog', 'dynatrace', 'elastic', 'ganglia', 'graphite', 'humio', 'influx', 'instana', 'jmx', 'kairos', 'new-relic', 'prometheus', 'signalFx', 'stackdriver', 'statsD', 'wavefront'];
+const systems = ['appOptics', 'atlas', 'azure-monitor', 'cloudwatch', 'datadog', 'dynatrace', 'elastic', 'ganglia', 'graphite', 'humio', 'influx', 'instana', 'jmx', 'kairos', 'new-relic', 'prometheus', 'signalFx', 'stackdriver', 'statsD', 'wavefront'];
 
 let docsBySystem = {};
 systems.forEach(sys => docsBySystem[sys] = require(`!asciidoc-loader!../../docs/implementations/${sys}.adoc`));

--- a/src/docs/implementations/cloudwatch.adoc
+++ b/src/docs/implementations/cloudwatch.adoc
@@ -1,0 +1,45 @@
+= Micrometer CloudWatch
+Tommy Ludwig <tludwig@vmware.com>
+:toc:
+:sectnums:
+:system: cloudwatch2
+
+https://aws.amazon.com/cloudwatch/:[Amazon CloudWatch] is a dimensional time-series SaaS on Amazon's cloud.
+
+include::install.adoc[]
+
+NOTE: `micrometer-registry-cloudwatch2` module uses AWS SDK v2. `micrometer-registry-cloudwatch` is for AWS SDK v1. 
+
+== Configuring
+
+[source,java]
+----
+CloudWatchConfig cloudWatchConfig = new CloudWatchConfig() {
+    @Override
+    public String get(String s) {
+        return null;
+    }
+
+    @Override
+    public String namespace() {
+        return "mynamespace";
+    }
+};
+MeterRegistry meterRegistry = new CloudWatchMeterRegistry(cloudWatchConfig, Clock.SYSTEM, CloudWatchAsyncClient.create());
+----
+
+You can provide your own `CloudWatchAsyncClient` to the constructor of the registry.
+
+`CloudWatchConfig` is an interface with a set of default methods. If, in the implementation of `get(String k)`, rather than returning `null`, you instead bind it to a property source, you can override the default configuration. For example, https://docs.awspring.io/spring-cloud-aws/docs/current/reference/html/index.html#cloudwatch-metrics[Micrometer support in Spring Cloud AWS] binds properties prefixed with `management.metrics.export.cloudwatch` directly to the `CloudWatchConfig`:
+
+[source,yml]
+----
+management.metrics.export.cloudwatch:
+    namespace: YOURNAMESPACE
+
+    # You will probably want disable publishing in a local development profile.
+    enabled: true
+
+    # The interval at which metrics are sent to CloudWatch. The default is 1 minute.
+    step: 1m
+----


### PR DESCRIPTION
An initial attempt to document the CloudWatch registry. We can build on this by adding additional pertinent information in subsequent pull requests.

Fixes #49 