### PR TITLE
Document how to use DatadogConfig.hostTag()

### DIFF
--- a/src/docs/implementations/datadog.adoc
+++ b/src/docs/implementations/datadog.adoc
@@ -63,6 +63,14 @@ management.metrics.export.datadog:
     step: 1m
 ----
 
+`DatadogConfig.hostTag()` specifies a tag key that will be mapped to https://docs.datadoghq.com/api/v1/metrics/#submit-metrics[the `host` field] when shipping metrics to Datadog.
+For example, if `DatadogConfig.hostTag()` returns "host", the tag having "host" as its key will be used.
+You can set the tag via common tags as follows:
+
+```java
+registry.config().commonTags("host", "my-host");
+```
+
 === Through Dogstatsd approach
 
 In Gradle:


### PR DESCRIPTION
This PR documents how to use `DatadogConfig.hostTag()`.

Closes gh-70