### PR TITLE
Update memory footprint estimation for histograms for 1.2.0

### DIFF
--- a/src/docs/concepts/distribution-summaries.adoc
+++ b/src/docs/concepts/distribution-summaries.adoc
@@ -59,7 +59,7 @@ The total memory footprint of a distribution summary can vary dramatically depen
 * R = Ring buffer length. We assume the default of 3 in all examples. R is set with `DistributionSummary.Builder#distributionStatisticBufferLength`.
 * B = Total histogram buckets. Can be SLA boundaries or percentile histogram buckets. By default, summaries have NO minimum and maximum expected value, so ship all 276 predetermined histogram buckets. You should always clamp distribution summaries with a `minimumExpectedValue` and `maximumExpectedValue` when you intend to ship percentile histograms.
 * M = Time-decaying max. 104 bytes
-* Fb = Fixed boundary histogram. 30b * B * R
+* Fb = Fixed boundary histogram. 8b * B * R
 * Pp = Percentile precision. By default is 1. Generally in the range [0, 3]. Pp is set with `DistributionSummary.Builder#percentilePrecision`.
 * Hdr(Pp) = High dynamic range histogram.
   - When Pp = 0: 1.9kb * R + 0.8kb

--- a/src/docs/concepts/timers.adoc
+++ b/src/docs/concepts/timers.adoc
@@ -170,7 +170,7 @@ Timers are the most memory-consuming meter, and their total footprint can vary d
 * B = Total histogram buckets. Can be SLA boundaries or percentile histogram buckets. By default, timers are clamped to a minimum expected value of 1ms and a maximum expected value of 30 seconds, yielding 66 buckets for percentile histograms, when applicable.
 * I = Interval estimator for pause compensation. 1.7 kb
 * M = Time-decaying max. 104 bytes
-* Fb = Fixed boundary histogram. 30b * B * R
+* Fb = Fixed boundary histogram. 8b * B * R
 * Pp = Percentile precision. By default is 1. Generally in the range [0, 3]. Pp is set with `Timer.Builder#percentilePrecision`.
 * Hdr(Pp) = High dynamic range histogram.
   - When Pp = 0: 1.9kb * R + 0.8kb


### PR DESCRIPTION
This PR updates memory footprint estimation for histograms for 1.2.0.

Closes gh-73