### PR TITLE
Fix typo in ElasticSeach default index name

### DIFF
--- a/src/docs/implementations/elastic.adoc
+++ b/src/docs/implementations/elastic.adoc
@@ -33,6 +33,6 @@ management.metrics.export.elastic:
     # The interval at which metrics are sent to Elastic. The default is 1 minute.
     step: 1m
 
-    # The index to store metrics in, defaults to "metrics"
-    index: metrics
+    # The index to store metrics in, defaults to "micrometer-metrics"
+    index: micrometer-metrics
 ----


### PR DESCRIPTION
Hi,

Playing a bit with micrometer and looking at the docs I found out that the default index name is micrometer-metrics and not metrics (see https://github.com/micrometer-metrics/micrometer/blob/b585495a65e4d911845a09c9adb88880761a0339/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java#L76).

Hope this helps and thanks for the great work!