### PR TITLE
Site host migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     working_directory: ~/micrometer-docs
     docker:
-      - image: circleci/node:11
+      - image: cimg/node:14.15
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ workflows:
   build_and_deploy:
     jobs:
       - build
-      - cloudfoundry/dark_deploy:
+      - cloudfoundry/blue_green:
           filters:
             branches:
               only:
@@ -51,22 +51,11 @@ workflows:
           requires:
             - build
           appname: micrometer-docs
-          manifest: manifest.yml
-          org: FrameworksAndRuntimes
-          space: micrometer-production
-          package: build
-          workspace_path: '.'
-          dark_subdomain: micrometer-docs-dark
-          domain: cfapps.io
-      - hold:
-          requires:
-            - cloudfoundry/dark_deploy
-          type: approval
-      - cloudfoundry/live_deploy:
-          requires:
-            - hold
-          appname: micrometer-docs
-          org: FrameworksAndRuntimes
-          space: micrometer-production
-          live_subdomain: ''
           domain: micrometer.io
+          endpoint: https://api.run.pcfone.io
+          live_subdomain: ''
+          manifest: manifest.yml
+          org: group-spring
+          package: build
+          space: micrometer.io
+          workspace_path: '.'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cloudfoundry: circleci/cloudfoundry@0.1.38
+  cloudfoundry: circleci/cloudfoundry@0.1.73
 
 jobs:
   build:


### PR DESCRIPTION
Moves the target endpoint to the new deployment for the docs site. Incidentally updates the CF orb and the build image to the latest stable versions. This also removals the manual approval step the previously existed as it has proven to be more time consuming than is warranted for deploying our docs site changes. The deployment is still zero-downtime using a blue-green deployment, but without a manual approval step.

Background: PWS (our current host) has [announced its end of availability](https://run.pivotal.io/faq/).