### PR TITLE
Add note for yarn install to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo is the source code for [micrometer.io](https://micrometer.io).
 
 This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).
 
-To check changes to this repository locally use `yarn start` for development mode. To run the build use `yarn build`.
+To check changes to this repository locally use `yarn start` for development mode. To run the build use `yarn build`. Note that you need to run `yarn` or `yarn install` first to install all the dependencies defined in a `package.json` file.
 
 -------------------------------------
 _Licensed under [Apache Software License 2.0](https://www.apache.org/licenses/LICENSE-2.0)_


### PR DESCRIPTION
This PR adds a note for `yarn install` to `README.md` as running `yarn start` without the step will throw an error as follows:

```
➜  micrometer-docs git:(master) yarn start
yarn run v1.22.10
$ react-scripts start
/bin/sh: react-scripts: command not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
➜  micrometer-docs git:(master) 
```