### PR TITLE
Document DogStatsD UDP origin detection feature

### DIFF
--- a/src/docs/implementations/datadog.adoc
+++ b/src/docs/implementations/datadog.adoc
@@ -8,7 +8,7 @@ Datadog is a dimensional time-series SaaS with built-in dashboarding and alertin
 
 == Installation and Configuration
 
-Micrometer supports shipping metrics to Datadog directly via its API or through Dogstatsd via the StatsD registry.
+Micrometer supports shipping metrics to Datadog directly via its API or through DogStatsD via the StatsD registry.
 The API approach is far more efficient if you need to choose between the two.
 
 === Direct to Datadog API approach
@@ -71,7 +71,7 @@ You can set the tag via common tags as follows:
 registry.config().commonTags("host", "my-host");
 ```
 
-=== Through Dogstatsd approach
+=== Through DogStatsD approach
 
 In Gradle:
 
@@ -91,7 +91,7 @@ Or in Maven:
 </dependency>
 ----
 
-Metrics are shipped immediately over UDP to Dogstatsd using Datadog's flavor of the StatsD line protocol. `java-dogstatsd-client` is _not_ needed on the classpath for this to work. Micrometer uses an alternative, non-blocking UDP implementation.
+Metrics are shipped immediately over UDP to DogStatsD using Datadog's flavor of the StatsD line protocol. `java-dogstatsd-client` is _not_ needed on the classpath for this to work as Micrometer uses its own implementation.
 
 [source,java]
 ----
@@ -109,3 +109,5 @@ StatsdConfig config = new StatsdConfig() {
 
 MeterRegistry registry = new StatsdMeterRegistry(config, Clock.SYSTEM);
 ----
+
+Micrometer supports UDP origin detection since 1.7.0.

--- a/src/docs/implementations/statsD.adoc
+++ b/src/docs/implementations/statsD.adoc
@@ -4,7 +4,7 @@ Jon Schneider <jschneider@pivotal.io>
 :sectnums:
 :system: statsd
 
-StatsD is a UDP-based sidecar-driven metrics collection system. The maintainer of the original StatsD line protocol specification is Etsy. Datadog's Dogstatsd and Influx's Telegraf each accept a modified version of the line protocol, having each enriched the original specification with dimensionality in different ways.
+StatsD is a UDP-based sidecar-driven metrics collection system. The maintainer of the original StatsD line protocol specification is Etsy. Datadog's DogStatsD and Influx's Telegraf each accept a modified version of the line protocol, having each enriched the original specification with dimensionality in different ways.
 
 If you intend to use the Datadog or Telegraf flavors, see the documentation for Micrometer's link:/docs/registry/datadog[Datadog] or link:/docs/registry/influx[Influx] support.
 


### PR DESCRIPTION
This PR documents DogStatsD UDP origin detection feature.

This PR also polishes a bit by:

- Replacing "Dogstatsd" with "DogStatsD" that seems to be its official name based on [its doc](https://github.com/DataDog/java-dogstatsd-client/tree/master#java-dogstatsd-client).
- Rewording based on https://github.com/micrometer-metrics/micrometer/issues/2578.

Closes gh-158