### PR TITLE
Use main for micrometer default branch

### DIFF
--- a/src/docs/installing/index.adoc
+++ b/src/docs/installing/index.adoc
@@ -26,7 +26,7 @@ If you haven't decided on a monitoring system yet and just want to try out the i
 
 == Snapshots
 
-Every successful https://app.circleci.com/pipelines/github/micrometer-metrics/micrometer[build] of Micrometer's master branch results in the publication of a new snapshot version. You can use the latest snapshot by adding the Maven repository `https://repo.spring.io/libs-snapshot` to your build and using the corresponding snapshot version, e.g. `1.2.0-SNAPSHOT`.
+Every successful https://app.circleci.com/pipelines/github/micrometer-metrics/micrometer[build] of Micrometer's main branch results in the publication of a new snapshot version. You can use the latest snapshot by adding the Maven repository `https://repo.spring.io/libs-snapshot` to your build and using the corresponding snapshot version, e.g. `1.2.0-SNAPSHOT`.
 
 == Spring Boot 1.5.x
 

--- a/src/docs/spring/spring-configuring.adoc
+++ b/src/docs/spring/spring-configuring.adoc
@@ -134,7 +134,7 @@ management.metrics.export.datadog.step=PT10S
 ----
 
 For a full list of configuration properties that can influence Datadog publishing, see
-[`io.micrometer.core.instrument.datadog.DatadogConfig`](https://github.com/micrometer-metrics/micrometer/blob/master/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogConfig.java).
+[`io.micrometer.core.instrument.datadog.DatadogConfig`](https://github.com/micrometer-metrics/micrometer/blob/main/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogConfig.java).
 
 == StatsD
 


### PR DESCRIPTION
This PR changes to use `main` for micrometer default branch as it has been renamed from `master`.