### PR TITLE
Remove mention of supported versions in project's README

### DIFF
--- a/src/docs/support/index.adoc
+++ b/src/docs/support/index.adoc
@@ -14,7 +14,7 @@ Designation of LTS and non-LTS releases
 
   * LTS and non-LTS minor releases are not differentiated by their version number alone, i.e. Micrometer will follow standard semantic versioning in its version numbers.
   * LTS releases are marked as such on https://github.com/micrometer-metrics/micrometer/releases[the GitHub releases].
-  * All supported versions are maintained in the following table indicating LTS/non-LTS status and in the project https://github.com/micrometer-metrics/micrometer[README on GitHub].
+  * All supported versions are maintained in the following table indicating LTS/non-LTS status.
 ====
 
 ## Released versions


### PR DESCRIPTION
This PR removes the mention of supported versions in the project's `README.md` as it has been removed in https://github.com/micrometer-metrics/micrometer/commit/5dd4ffc6e324915715655f779354f98871e275f9.