### PR TITLE
Use implementation configuration for Gradle samples

### DIFF
--- a/src/docs/implementations/datadog.adoc
+++ b/src/docs/implementations/datadog.adoc
@@ -17,7 +17,7 @@ In Gradle:
 
 [source,groovy]
 ----
-compile 'io.micrometer:micrometer-registry-datadog:latest.release'
+implementation 'io.micrometer:micrometer-registry-datadog:latest.release'
 ----
 
 Or in Maven:
@@ -77,7 +77,7 @@ In Gradle:
 
 [source,groovy,subs=+attributes]
 ----
-compile 'io.micrometer:micrometer-registry-statsd:latest.release'
+implementation 'io.micrometer:micrometer-registry-statsd:latest.release'
 ----
 
 Or in Maven:

--- a/src/docs/implementations/influx.adoc
+++ b/src/docs/implementations/influx.adoc
@@ -18,7 +18,7 @@ In Gradle:
 
 [source,groovy]
 ----
-compile 'io.micrometer:micrometer-registry-influx:latest.release'
+implementation 'io.micrometer:micrometer-registry-influx:latest.release'
 ----
 
 Or in Maven:
@@ -86,7 +86,7 @@ In Gradle:
 
 [source,groovy]
 ----
-compile 'io.micrometer:micrometer-registry-statsd:latest.release'
+implementation 'io.micrometer:micrometer-registry-statsd:latest.release'
 ----
 
 Or in Maven:

--- a/src/docs/implementations/install.adoc
+++ b/src/docs/implementations/install.adoc
@@ -4,7 +4,7 @@ In Gradle:
 
 [source,groovy,subs=+attributes]
 ----
-compile 'io.micrometer:micrometer-registry-{system}:latest.release'
+implementation 'io.micrometer:micrometer-registry-{system}:latest.release'
 ----
 
 Or in Maven:

--- a/src/docs/installing/index.adoc
+++ b/src/docs/installing/index.adoc
@@ -6,7 +6,7 @@ In Gradle:
 
 [source,groovy]
 ----
-compile 'io.micrometer:micrometer-registry-prometheus:latest.release'
+implementation 'io.micrometer:micrometer-registry-prometheus:latest.release'
 ----
 
 Or in Maven:

--- a/src/docs/spring/index.adoc
+++ b/src/docs/spring/index.adoc
@@ -15,7 +15,7 @@ In Gradle:
 
 [source,groovy,subs=+attributes]
 ----
-compile 'io.micrometer:micrometer-spring-legacy:latest.release'
+implementation 'io.micrometer:micrometer-spring-legacy:latest.release'
 ----
 
 Or in Maven:

--- a/src/docs/spring/spring-configuring.adoc
+++ b/src/docs/spring/spring-configuring.adoc
@@ -79,7 +79,7 @@ To add actuator if it isn't already present on your classpath in Gradle:
 
 [source,groovy]
 ----
-compile 'org.springframework.boot:spring-boot-starter-actuator'
+implementation 'org.springframework.boot:spring-boot-starter-actuator'
 ----
 
 Or in Maven:


### PR DESCRIPTION
The `compile` configuration has been deprecated and
was removed in Gradle 7.