### PR TITLE
Clarify LongTaskTimer output

### DIFF
--- a/src/docs/concepts/long-task-timers.adoc
+++ b/src/docs/concepts/long-task-timers.adoc
@@ -1,6 +1,14 @@
-The long task timer is a special type of timer that lets you measure time while an event being measured is *still running*. A timer does not record the duration until the task is complete.
+The long task timer is a special type of timer that lets you measure time while an event being measured is *still running*. A normal Timer only records the duration *after* the task is complete.
 
-Now consider a background process to refresh metadata from a data store. For example, Edda caches AWS resources such as instances, volumes, auto-scaling groups, and others . Normally all data can be refreshed in a few minutes. If the AWS services have problems, it can take much longer. A long duration timer can be used to track the overall time for refreshing the metadata.
+Long task timers publish at least the following statistics:
+
+* active task count
+* total duration of active tasks
+* max duration of active tasks
+
+Unlike a regular `Timer`, a long task timer does not publish statistics about completed tasks.
+
+Consider a background process to refresh metadata from a data store. For example, https://github.com/Netflix/edda[Edda] caches AWS resources such as instances, volumes, auto-scaling groups, and others. Normally all data can be refreshed in a few minutes. If the AWS services have problems, it can take much longer. A long task timer can be used to track the active time for refreshing the metadata.
 
 For example, in a Spring application, it is common for such long running processes to be implemented with `@Scheduled`. Micrometer provides a special `@Timed` annotation for instrumenting these processes with a long task timer.
 


### PR DESCRIPTION
Explicitly mention what is published.
Make clear it is info on active tasks only.

Resolves #179