### PR TITLE
Stackdriver resource type/labels and unique tagging docs

### DIFF
--- a/src/docs/implementations/stackdriver.adoc
+++ b/src/docs/implementations/stackdriver.adoc
@@ -85,6 +85,8 @@ MeterRegistry registry = StackdriverMeterRegistry.builder(stackdriverConfig).bui
 registry.config().commonTags("application", "my-application");
 ----
 
+IMPORTANT: If using Micrometer across multiple applications/instances, it is important to configure a common tag so metrics will be unique per application/instance. Otherwise, you will see errors like `One or more TimeSeries could not be written: One or more points were written more frequently than the maximum sampling period configured`. Using the hostname or platform-provided instance ID may be a good candidate for achieving this.
+
 == Spring Boot
 
 NOTE: Since Spring Boot 2.3, Micrometer Stackdriver auto-configuration is supported. For more information review the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-metrics-export-stackdriver[Spring Boot docs].

--- a/src/docs/implementations/stackdriver.adoc
+++ b/src/docs/implementations/stackdriver.adoc
@@ -35,6 +35,7 @@ MeterRegistry registry = StackdriverMeterRegistry.builder(stackdriverConfig).bui
 ----
 management.metrics.export.stackdriver:
     project-id: MY_PROJECT_ID
+    resource-type: global
 
     # You will probably want to disable Stackdriver Monitoring publishing in a local development profile.
     enabled: true
@@ -74,7 +75,7 @@ you don't need to configure this environmental variable. In those environments, 
 automatically associated with the application instance. The underlying Stackdriver Monitoring client
 library can automatically detect and use those credentials.
 
-== Stackdriver Metrics Labels
+== Stackdriver Labels
 
 Micrometer metrics tags are mapped to https://cloud.google.com/monitoring/api/v3/metrics-details#intro-time-series[Stackdriver metrics labels]. With tags/labels, you can further filter or group
 by the tag/label. See link:/docs/concepts#_tag_naming[Micrometer Concepts] for more information on tags.
@@ -85,11 +86,13 @@ MeterRegistry registry = StackdriverMeterRegistry.builder(stackdriverConfig).bui
 registry.config().commonTags("application", "my-application");
 ----
 
-IMPORTANT: If using Micrometer across multiple applications/instances, it is important to configure a common tag so metrics will be unique per application/instance. Otherwise, you will see errors like `One or more TimeSeries could not be written: One or more points were written more frequently than the maximum sampling period configured`. Using the hostname or platform-provided instance ID may be a good candidate for achieving this.
+You can also configure resource labels with the `StackdriverConfig` method `resourceLabels`. Depending on the configured `resourceType`, there will be required resource labels. See the documentation on https://cloud.google.com/monitoring/custom-metrics/creating-metrics#which-resource[choosing a monitored resource type].
+
+IMPORTANT: When using Micrometer across multiple applications/instances, it is necessary that Stackdriver labels are unique per application/instance. Otherwise, you will see errors like `One or more TimeSeries could not be written: One or more points were written more frequently than the maximum sampling period configured`. If using a resource type other than `global`, the resource labels may already make metrics unique per application instance. If not, a common tag with the hostname or platform-provided instance ID may be a good candidate for achieving this.
 
 == Spring Boot
 
-NOTE: Since Spring Boot 2.3, Micrometer Stackdriver auto-configuration is supported. For more information review the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-metrics-export-stackdriver[Spring Boot docs].
+Spring Boot provides auto-configuration for Micrometer's StackdriverMeterRegistry. For more information review the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-metrics-export-stackdriver[Spring Boot docs].
 
 You can manually configure/register the `StackdriverMeterRegistry`.
 In addition to using Spring Boot Actuator, make sure you create the `StackdriverMeterRegistry` bean:


### PR DESCRIPTION
Stackdriver fails to write metrics if two application instances are trying to write identical metrics in the same interval. To make the meters unique, a label or labels unique to the instance should be configured either as common tags or as resource labels.

This is documenting what we believe is the underlying cause of users running into the errors mentioned in https://github.com/micrometer-metrics/micrometer/issues/1335.

It also adds information about resource type and resource labels, which was missing from the documentation until now.