### PR TITLE
Update information on autoconfig for Dynatrace Operator

### DIFF
--- a/src/docs/implementations/dynatrace.adoc
+++ b/src/docs/implementations/dynatrace.adoc
@@ -4,7 +4,8 @@
 :system: dynatrace
 
 https://www.dynatrace.com/[*Dynatrace*] is a Software Intelligence Platform featuring application performance monitoring (APM), artificial intelligence for operations (AIOps), IT infrastructure monitoring, digital experience management (DEM), and digital business analytics capabilities.
-It can ingest multi-purpose dimensional time-series data and has built-in dashboarding. Both SaaS and self-hosted (Managed) deployments are offered.
+It can ingest multi-purpose dimensional time-series data and has built-in dashboarding.
+Both SaaS and self-hosted (Managed) deployments are offered.
 
 include::install.adoc[]
 
@@ -27,7 +28,8 @@ DynatraceConfig dynatraceConfig = new DynatraceConfig() {
     @Override
     @Nullable
     public String get(String k) {
-        // This method for retrieving arbitrary config items introduced by the interface is currently not used in DynatraceConfig.
+        // This method of the interface is used by the other configuration methods and needs to be
+        // implemented here. Returning null accepts the defaults for the other configuration items.
         return null;
     }
 };
@@ -46,11 +48,12 @@ DynatraceConfig dynatraceConfig = new DynatraceConfig() {
 
     @Override
     @Nullable
-    public String get(String k) { return null; }
+    public String get(String k) {
+        return null; // accept the rest of the defaults
+    }
 };
 MeterRegistry registry = new DynatraceMeterRegistry(dynatraceConfig, Clock.SYSTEM);
 ----
-
 
 `DynatraceConfig` is an interface with a set of default methods.
 Spring Boot's Micrometer support binds properties prefixed with `management.metrics.export.dynatrace` directly to the `DynatraceConfig`.
@@ -93,17 +96,14 @@ DynatraceConfig dynatraceConfig = new DynatraceConfig() {
     @Override
     @Nullable
     public String get(String k) {
-        // This method can be used for retrieving arbitrary config items,
-        // null means accepting the defaults defined in DynatraceConfig
-        return null;
+        return null; // accept the rest of the defaults
     }
 };
 MeterRegistry registry = new DynatraceMeterRegistry(dynatraceConfig, Clock.SYSTEM);
 ----
 
 These properties can also be set via Spring Boot, using property or yaml files.
-It is also possible to reference environment variables using the Spring property placeholders
-(e.g.: `management.metrics.export.dynatrace.uri: ${DT_METRICS_INGEST_URL}`).
+It is also possible to reference environment variables using the Spring property placeholders (e.g.: `management.metrics.export.dynatrace.uri: ${DT_METRICS_INGEST_URL}`).
 
 NOTE: `v2` is used as the default API version unless a `deviceId` is set (<<bookmark-apiv1, see below>>).
 
@@ -241,7 +241,6 @@ The `device-id` property is required for `v1` and not used in `v2`.
 Existing setups will continue to work when updating to newer versions of Micrometer.
 The reported metrics will be assigned to https://www.dynatrace.com/support/help/dynatrace-api/environment-api/topology-and-smartscape/custom-device-api/report-custom-device-metric-via-rest-api/[custom devices] in Dynatrace.
 
-
 For the v1 API, do not specify the ingest path, but only the base URL of your environment, e.g.: `uri: https://{your-environment-id}.live.dynatrace.com`
 
 [source,java]
@@ -268,7 +267,7 @@ DynatraceConfig dynatraceConfig = new DynatraceConfig() {
     @Override
     @Nullable
     public String get(String k) {
-        return null;
+        return null; // accept the rest of the defaults
     }
 };
 MeterRegistry registry = new DynatraceMeterRegistry(dynatraceConfig, Clock.SYSTEM);

--- a/src/docs/implementations/dynatrace.adoc
+++ b/src/docs/implementations/dynatrace.adoc
@@ -13,10 +13,13 @@ include::install.adoc[]
 For setting up new integrations with Dynatrace, it is recommended to use the latest version of the https://www.dynatrace.com/support/help/dynatrace-api/environment-api/metric-v2/[Dynatrace Metrics API] (v2).
 Dynatrace provides different ways of setting up integrations:
 
-=== Using a Dynatrace OneAgent installed on the host (preferred) [[bookmark-oneagent-example]]
+=== Using Dynatrace auto-configuration (preferred) [[bookmark-auto-configuration]]
+
+Dynatrace auto-configuration is available for hosts that are monitored by a OneAgent or by the Dynatrace Operator for Kubernetes.
 
 If a Dynatrace OneAgent is installed on the host running Micrometer, metrics can be exported directly using the OneAgent without having to specify an endpoint URI or API token.
-Use the following code in your project to export Micrometer metrics to the https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/local-api/[local OneAgent endpoint]:
+If running in Kubernetes with the Dynatrace operator installed, the registry will pick up your endpoint URI and API token from the operator instead.
+In this case there is no need to configure anything, you can use the following code in your project to export Micrometer metrics to Dynatrace:
 
 [source,java]
 ----
@@ -24,8 +27,7 @@ DynatraceConfig dynatraceConfig = new DynatraceConfig() {
     @Override
     @Nullable
     public String get(String k) {
-        // This method can be used for retrieving arbitrary config items,
-        // null means accepting the defaults defined in DynatraceConfig
+        // This method for retrieving arbitrary config items introduced by the interface is currently not used in DynatraceConfig.
         return null;
     }
 };
@@ -44,9 +46,7 @@ DynatraceConfig dynatraceConfig = new DynatraceConfig() {
 
     @Override
     @Nullable
-    public String get(String k) {
-        return null; // accept the rest of the defaults
-    }
+    public String get(String k) { return null; }
 };
 MeterRegistry registry = new DynatraceMeterRegistry(dynatraceConfig, Clock.SYSTEM);
 ----
@@ -57,11 +57,11 @@ Spring Boot's Micrometer support binds properties prefixed with `management.metr
 This allows configuring the Dynatrace exporter by using the <<bookmark-available-properties, the available properties>>.
 
 To use the Dynatrace metrics exporter for Micrometer in your Spring Boot project, it is enough to include the `runtimeOnly 'io.micrometer:micrometer-registry-dynatrace'` dependency.
-In this default configuration, metrics will be exported to the local OneAgent endpoint.
+In this default configuration, metrics will be exported to the local OneAgent or Kubernetes operator-provided endpoint.
 
 === Using a custom endpoint
 
-If no Dynatrace OneAgent is available on the host, both the Dynatrace Metrics API v2 endpoint and an API token have to be specified.
+If auto-configuration is not available on the host, both the Dynatrace Metrics API v2 endpoint and an API token have to be specified.
 The https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication/[Dynatrace API token documentation] contains more information on how to create an API token.
 The 'Ingest metrics' (`metrics.ingest`) permission is required on the token in order to ingest metrics.
 It is recommended to limit scope to only this permission.
@@ -79,14 +79,14 @@ DynatraceConfig dynatraceConfig = new DynatraceConfig() {
     public String uri() {
         // The endpoint of the Dynatrace Metrics API v2 including path, e.g.:
         // "https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest"
-        String endpoint = System.getenv("YOUR_METRICS_INGEST_URL");
+        String endpoint = System.getenv("ENVVAR_METRICS_INGEST_URL");
         return endpoint != null ? endpoint : DynatraceConfig.super.uri();
     }
 
     @Override
     public String apiToken() {
         // should be read from a secure source
-        String token = System.getenv("YOUR_METRICS_INGEST_TOKEN");
+        String token = System.getenv("ENVVAR_METRICS_INGEST_TOKEN");
         return token != null ? token : "";
     }
 
@@ -101,11 +101,11 @@ DynatraceConfig dynatraceConfig = new DynatraceConfig() {
 MeterRegistry registry = new DynatraceMeterRegistry(dynatraceConfig, Clock.SYSTEM);
 ----
 
-These properties can also be set via Spring Boot, using property/yaml files.
+These properties can also be set via Spring Boot, using property or yaml files.
 It is also possible to reference environment variables using the Spring property placeholders
 (e.g.: `management.metrics.export.dynatrace.uri: ${DT_METRICS_INGEST_URL}`).
 
-NOTE: `v2` is used as the default API version unless a `deviceId`` is set (<<bookmark-apiv1, see below>>).
+NOTE: `v2` is used as the default API version unless a `deviceId` is set (<<bookmark-apiv1, see below>>).
 
 [source,yml]
 ----
@@ -125,18 +125,20 @@ management.metrics.export.dynatrace:
 When the API version is configured to `v2`, the registry will send data using the https://www.dynatrace.com/support/help/dynatrace-api/environment-api/metric-v2/[Metrics API v2].
 In order to maintain backwards compatibility, when a `deviceId` is set (which is required for `v1` and not used in `v2`), `v1` is used as the default.
 Otherwise, the version defaults to `v2`, and does not have to be set explicitly.
-With no endpoint URL and token set, metrics will be exported to the local OneAgent endpoint.
-If no OneAgent is running on the target host, it is possible to specify endpoint and token explicitly, in order to export metrics to that specific endpoint.
+With no endpoint URI and token set, metrics will be exported to the local OneAgent endpoint or, if a running in Kubernetes with the Dynatrace operator installed, to the endpoint provided by the operator.
+If no auto-configuration is desired, it is possible to specify endpoint and token explicitly, in order to export metrics to that specific endpoint.
+Explicitly specifying these will overwrite auto-configuration.
 
-*Minimal configuration with a local Dynatrace OneAgent*
+*Minimal configuration with Dynatrace auto-configuration*
 
-In the minimal configuration <<bookmark-oneagent-example, shown above>> (no URI or API token), the v2 exporter will attempt to export to the https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/local-api/[local OneAgent metrics ingest endpoint].
-Note that this only works if a OneAgent is running on the host and the https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/local-api/#enable-the-oneagent-metric-api[local OneAgent Metric API] is available.
-If the ingestion port was changed to a custom one, the full endpoint URI has to be provided for the URI property (with API token left empty).
+In the minimal configuration <<bookmark-auto-configuration, shown above>> (no URI or API token), the v2 registry will attempt to retrieve the endpoint provided by the Dynatrace Kubernetes operator.
+If the operator is not set up or does not provide this information, the exporter will attempt to send metrics to the https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/local-api/[local OneAgent metrics ingest endpoint].
+Note that this only works if the a OneAgent is running on the host and the https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/local-api/#enable-the-oneagent-metric-api[local OneAgent Metric API] is available.
+If the ingestion port for the local OneAgent was changed to a custom one, the full endpoint URI has to be provided for the URI property (with API token left empty).
 
 *Configuration with URI and API token*
 
-If no local OneAgent is running on the host or the metrics should be sent to a different endpoint (e.g. a different tenant), the Dynatrace v2 exporter can be configured with an explicit endpoint URI and an https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication/[API token].
+If no auto-configuration is available or the metrics should be sent to a different endpoint (e.g. a different tenant), the Dynatrace v2 exporter can be configured with an explicit endpoint URI and an https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication/[API token].
 The https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication/[API token] must have the https://www.dynatrace.com/support/help/shortlink/api-authentication#token-permissions["Ingest metrics"] (`metrics.ingest`) permission set.
 It is recommended to limit scope to only this permission.
 
@@ -191,14 +193,14 @@ DynatraceConfig dynatraceConfig = new DynatraceConfig() {
     public String uri() {
         // The endpoint of the Dynatrace Metrics API v2 including path, e.g.:
         // "https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest".
-        String endpoint = System.getenv("DT_METRICS_INGEST_URL");
+        String endpoint = System.getenv("ENVVAR_METRICS_INGEST_URL");
         return endpoint != null ? endpoint : DynatraceConfig.super.uri();
     }
 
     @Override
     public String apiToken() {
         // should be read from a secure source
-        String token = System.getenv("DT_METRICS_INGEST_API_TOKEN");
+        String token = System.getenv("ENVVAR_METRICS_INGEST_TOKEN");
         return token != null ? token : "";
     }
 


### PR DESCRIPTION
This is a companion PR for https://github.com/micrometer-metrics/micrometer/pull/2916, clarifying the documentation for the Dynatrace Operator based configuration.

This PR should probably only be merged after the actual feature is added to the next Micrometer minor release (1.9.0, I assume).