### PR TITLE
Replace sla() with serviceLevelObjectives()

### DIFF
--- a/src/docs/concepts/distribution-summaries.adoc
+++ b/src/docs/concepts/distribution-summaries.adoc
@@ -41,13 +41,13 @@ Instead, if your summary's domain is more constrained, scale your summary's rang
 DistributionSummary.builder("my.ratio").scale(100).register(registry)
 ----
 
-This way, the ratio winds up in the range [0,100] and we can set `maximumExpectedValue` to 100. You can pair this with custom SLA boundaries if you care about particular ratios:
+This way, the ratio winds up in the range [0,100] and we can set `maximumExpectedValue` to 100. You can pair this with custom SLO boundaries if you care about particular ratios:
 
 [source,java]
 ----
 DistributionSummary.builder("my.ratio")
    .scale(100)
-   .sla(70, 80, 90)
+   .serviceLevelObjectives(70, 80, 90)
    .register(registry)
 ----
 

--- a/src/docs/concepts/histogram-quantiles.adoc
+++ b/src/docs/concepts/histogram-quantiles.adoc
@@ -10,14 +10,14 @@ The following example builds a timer with a histogram:
 Timer.builder("my.timer")
    .publishPercentiles(0.5, 0.95) // median and 95th percentile <1>
    .publishPercentileHistogram() // <2>
-   .sla(Duration.ofMillis(100)) // <3>
+   .serviceLevelObjectives(Duration.ofMillis(100)) // <3>
    .minimumExpectedValue(Duration.ofMillis(1)) // <4>
    .maximumExpectedValue(Duration.ofSeconds(10))
 ----
 
 <1> `publishPercentiles`: Used to publish percentile values computed in your application. These values are non-aggregable across dimensions.
 <2> `publishPercentileHistogram`: Used to publish a histogram suitable for computing aggregable (across dimensions) percentile approximations in Prometheus (by using `histogram_quantile`), Atlas (by using `:percentile`), and Wavefront (by using `hs()`). For Prometheus and Atlas, the buckets in the resulting histogram are preset by Micrometer based on a generator that has been determined empirically by Netflix to yield a reasonable error bound on most real world timers and distribution summaries. By default, the generator yields 276 buckets, but Micrometer includes only those that are within the range set by `minimumExpectedValue` and `maximumExpectedValue`, inclusive. Micrometer clamps timers by default to a range of 1 millisecond to 1 minute, yielding 73 histogram buckets per timer dimension. `publishPercentileHistogram` has no effect on systems that do not support aggregable percentile approximations. No histogram is shipped for these systems.
-<3> `sla`: Used to publish a cumulative histogram with buckets defined by your SLAs. When used in concert with `publishPercentileHistogram` on a monitoring system that supports aggregable percentiles, this setting adds additional buckets to the published histogram. When used on a system that does not support aggregable percentiles, this setting causes a histogram to be published with only these buckets.
+<3> `serviceLevelObjectives`: Used to publish a cumulative histogram with buckets defined by your SLOs. When used in concert with `publishPercentileHistogram` on a monitoring system that supports aggregable percentiles, this setting adds additional buckets to the published histogram. When used on a system that does not support aggregable percentiles, this setting causes a histogram to be published with only these buckets.
 <4> `minimumExpectedValue`/`maximumExpectedValue`: Controls the number of buckets shipped by `publishPercentileHistogram` and controls the accuracy and memory footprint of the underlying HdrHistogram structure.
 
 Since shipping percentiles to the monitoring system generates additional time series, it is generally preferable to *not* configure them in core libraries that are included as dependencies in applications. Instead, applications can turn on this behavior for some set of timers and distribution summaries by using a meter filter.


### PR DESCRIPTION
This PR replaces deprecated `sla()` calls with `serviceLevelObjectives()` calls.