### PR TITLE
Small fixes for Dynatrace documentation

### DIFF
--- a/src/components/DocRoot/index.js
+++ b/src/components/DocRoot/index.js
@@ -53,8 +53,10 @@ export default function DocRoot() {
             </li>
 
             <li><NavLink className="doc-section" to="/docs/registry/dynatrace">Dynatrace</NavLink>. Dynatrace
-              is a dimensional time-series SAAS with built-in dashboarding. Micrometer supports shipping
-              metrics to Dynatrace directly via its API.
+              is a Software Intelligence Platform featuring application performance monitoring (APM), artificial
+              intelligence for operations (AIOps), IT infrastructure monitoring, digital experience management (DEM),
+              and digital business analytics capabilities. Micrometer supports shipping metrics to Dynatrace directly
+              via its API.
             </li>
 
             <li><NavLink className="doc-section" to="/docs/registry/elastic">Elastic</NavLink>. Elasticsearch is an

--- a/src/docs/concepts/implementations.adoc
+++ b/src/docs/concepts/implementations.adoc
@@ -19,7 +19,7 @@ Micrometer contains a core module with an instrumentation https://en.wikipedia.o
 |Client-side
 |Server-side
 
-|AppOptics, Atlas, Azure Monitor, Datadog, Elastic, Graphite, Ganglia, Humio, Influx, JMX, Kairos, New Relic, all StatsD flavors, SignalFx
+|AppOptics, Atlas, Azure Monitor, Datadog, Dynatrace, Elastic, Graphite, Ganglia, Humio, Influx, JMX, Kairos, New Relic, all StatsD flavors, SignalFx
 |Prometheus, Wavefront footnote:[As of 1.2.0, Micrometer sends cumulative values to Wavefront.]
 |===
 
@@ -30,7 +30,7 @@ Micrometer contains a core module with an instrumentation https://en.wikipedia.o
 |Client pushes
 |Server polls
 
-|AppOptics, Atlas, Azure Monitor, Datadog, Elastic, Graphite, Ganglia, Humio, Influx, JMX, Kairos, New Relic, SignalFx, Wavefront
+|AppOptics, Atlas, Azure Monitor, Datadog, Dynatrace, Elastic, Graphite, Ganglia, Humio, Influx, JMX, Kairos, New Relic, SignalFx, Wavefront
 |Prometheus, all StatsD flavors
 |===
 


### PR DESCRIPTION
* Updates the short description on the overview page to match the description on the Dynatrace detail page (https://micrometer.io/docs/registry/dynatrace)
* Adds Dynatrace to the rate aggregation and publishing sections