### PR TITLE
Fix code snippet for MultiGauge

### DIFF
--- a/src/docs/concepts/gauges.adoc
+++ b/src/docs/concepts/gauges.adoc
@@ -106,5 +106,7 @@ MultiGauge statuses = MultiGauge.builder("statuses")
 // run this periodically whenever you re-run your query
 statuses.register(
     resultSet.stream()
-        .map(result -> Row.of(Tags.of("status", result.getAsString("status")), result.getAsInt("count"))));
+        .map(result -> Row.of(Tags.of("status", result.getAsString("status")), result.getAsInt("count")))
+        .collect(toList())
+);
 ----


### PR DESCRIPTION
The method `MultiGauge::register` expects an argument of type `Iterable`. In the edited code snippet, it is currently passed a `Stream`, which is not a subtype of `Iterable`.