### PR TITLE
Add doc for Jetty and Jersey

### DIFF
--- a/src/components/DocRoot/index.js
+++ b/src/components/DocRoot/index.js
@@ -148,6 +148,8 @@ export default function DocRoot() {
             </li>
             <li><NavLink className="doc-section" to="/docs/ref/okhttpclient">OkHttpClient</NavLink>. Instrumentation for OkHttpClient.
             </li>
+            <li><NavLink className="doc-section" to="/docs/ref/jetty">Jetty and Jersey</NavLink>. Instrumentation for Jetty and Jersey.
+            </li>
           </ul>
         </li>
         <li><span className="doc-section">Guides</span>.

--- a/src/components/DocRoutes/index.js
+++ b/src/components/DocRoutes/index.js
@@ -10,6 +10,7 @@ let docsConcepts = require('!asciidoc-loader!../../docs/concepts/index.adoc');
 let docsJvm = require('!asciidoc-loader!../../docs/jvm/index.adoc');
 let docsCache = require('!asciidoc-loader!../../docs/cache/index.adoc');
 let docsOkHttpClient = require('!asciidoc-loader!../../docs/okhttpclient/index.adoc');
+let docsJetty = require('!asciidoc-loader!../../docs/jetty/index.adoc');
 let docsConsoleReporter = require('!asciidoc-loader!../../docs/guide/console-reporter.adoc');
 let docsHttpSenderResilience4jRetry = require('!asciidoc-loader!../../docs/guide/http-sender-resilience4j-retry.adoc');
 let docsCustomMeterRegistry = require('!asciidoc-loader!../../docs/guide/custom-meter-registry.adoc');
@@ -51,6 +52,10 @@ export default function DocRoutes() {
 
       <Route path="/docs/ref/okhttpclient" render={() =>
         <DocSection title="OkHttpClient Metrics" content={docsOkHttpClient}/>
+      }/>
+
+      <Route path="/docs/ref/jetty" render={() =>
+        <DocSection title="Jetty and Jersey Metrics" content={docsJetty}/>
       }/>
 
       <Route path="/docs/guide/consoleReporter" render={() =>

--- a/src/docs/jetty/index.adoc
+++ b/src/docs/jetty/index.adoc
@@ -1,0 +1,26 @@
+Micrometer supports binding metrics to `Jetty` through `Connection.Listener`.
+
+You can collect metrics from `Jetty` by adding `JettyConnectionMetrics` as follows:
+
+[source,java]
+----
+ Server server = new Server(0);
+ Connector connector = new ServerConnector(server);
+ connector.addBean(new JettyConnectionMetrics(registry, connector, Tags.of("foo", "bar"));
+ server.setConnectors(new Connector[] { connector });
+----
+
+Micrometer also supports binding metrics to `Jersey` through `ApplicationEventListener`.
+
+You can collect metrics from `Jersey` by adding `MetricsApplicationEventListener` as follows:
+
+[source,java]
+----
+ResourceConfig resourceConfig = new ResourceConfig();
+resourceConfig.register(new MetricsApplicationEventListener(
+                registry,
+                new DefaultJerseyTagsProvider(),
+                "jersey",
+                true));
+ServletContainer servletContainer = new ServletContainer(resourceConfig);
+----

--- a/src/docs/jetty/index.adoc
+++ b/src/docs/jetty/index.adoc
@@ -20,7 +20,7 @@ ResourceConfig resourceConfig = new ResourceConfig();
 resourceConfig.register(new MetricsApplicationEventListener(
                 registry,
                 new DefaultJerseyTagsProvider(),
-                "jersey",
+                "http.server.requests",
                 true));
 ServletContainer servletContainer = new ServletContainer(resourceConfig);
 ----


### PR DESCRIPTION
Instrumentation for Jetty and Jersey is used by Spring. In our [open source project](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/docs/metrics.md) which does not use Spring, we had to do some investigation to use this binding directly. [Others](https://stackoverflow.com/questions/68867934/example-of-embedded-jetty-and-using-micrometer-for-stats-without-spring) have gone through this too.

Having this in the public doc would be beneficial.