### PR TITLE
Update version tables since out of OSS support for 1.7.x

### DIFF
--- a/src/docs/implementations/datadog.adoc
+++ b/src/docs/implementations/datadog.adoc
@@ -110,13 +110,13 @@ StatsdConfig config = new StatsdConfig() {
 MeterRegistry registry = new StatsdMeterRegistry(config, Clock.SYSTEM);
 ----
 
-Since version 1.7.0, Micrometer supports DogStatsD's https://docs.datadoghq.com/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp[origin detection over UDP] feature on Kubernetes if the `DD_ENTITY_ID` environment variable is properly set.
+Micrometer supports DogStatsD's https://docs.datadoghq.com/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp[origin detection over UDP] feature on Kubernetes if the `DD_ENTITY_ID` environment variable is properly set.
 
 Micrometer, by default, publishes `Timer` meters to DogStatsD as the StatsD "timing" metric type `ms`,
 which are sent to Datadog as https://docs.datadoghq.com/metrics/types/?tab=histogram#metric-types[histogram] type metrics.
 Micrometer publishes `DistributionSummary` meters as histogram type metrics by default, also.
 
-Since version 1.8.0, when `percentileHistogram` is enabled for the meter, Micrometer sends `Timer` and `DistributionSummary` meters as Datadog https://docs.datadoghq.com/metrics/distributions[Distributions] to DogStatsD.
+When `percentileHistogram` is enabled for the meter, Micrometer sends `Timer` and `DistributionSummary` meters as Datadog https://docs.datadoghq.com/metrics/distributions[Distributions] to DogStatsD.
 You can make a `DistributionSummary` with `percentileHistogram` enabled as follows:
 
 [source,java]

--- a/src/docs/implementations/influx.adoc
+++ b/src/docs/implementations/influx.adoc
@@ -5,7 +5,7 @@
 
 The InfluxData suite of tools supports real-time stream processing and storage of time-series data. It supports downsampling, automatically expiring and deleting unwanted data, as well as backup and restore.
 
-Since Micrometer 1.7, the InfluxMeterRegistry supports the 1.x InfluxDB API as well as the v2 API.
+The InfluxMeterRegistry supports the 1.x InfluxDB API as well as the v2 API.
 
 == Configuring
 

--- a/src/docs/implementations/prometheus.adoc
+++ b/src/docs/implementations/prometheus.adoc
@@ -57,7 +57,7 @@ HttpServlet metricsServlet = new MetricsServlet(prometheusRegistry.getPrometheus
 
 By default, the https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format[Prometheus text format] is returned from the `PrometheusMeterRegistry` `scrape()` method.
 
-Since Micrometer 1.7.0, the https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md[OpenMetrics] format can also be produced.
+The https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md[OpenMetrics] format can also be produced.
 To specify the format to be returned, you can pass a content type to the `scrape` method.
 For example, to get the OpenMetrics 1.0.0 format scrape, you could use the Prometheus Java client constant for it, as follows:
 

--- a/src/docs/support/index.adoc
+++ b/src/docs/support/index.adoc
@@ -18,7 +18,6 @@ The following releases are actively maintained:
 | Minor release | OSS Support Until
 | 1.9.x         | May 2023
 | 1.8.x         | November 2022
-| 1.7.x         | May 2022
 |===========
 
 The following releases are out of OSS support:
@@ -27,6 +26,7 @@ The following releases are out of OSS support:
 [width="35%",options="header"]
 |===========
 | Minor release | Final patch
+| 1.7.x         | `1.7.12`
 | 1.6.x         | `1.6.13`
 | 1.5.x         | `1.5.17`
 | 1.4.x         | `1.4.2`


### PR DESCRIPTION
This PR updates the version tables since out of OSS support for 1.7.x.

This PR also cleans up unnecessary version info.