### PR TITLE
Document runtime dependencies

### DIFF
--- a/src/docs/concepts/index.adoc
+++ b/src/docs/concepts/index.adoc
@@ -13,6 +13,14 @@ Micrometer is _not_ a distributed tracing system or an event logger. In Micromet
 For better understanding the differences among these different types of systems (Metrics, Distributed Tracing, and Logging) we recommend Adrian Cole's talk, titled https://www.dotconferences.com/2017/04/adrian-cole-observability-3-ways-logging-metrics-tracing[Observability
 3 Ways].
 
+== Dependencies
+
+The `micrometer-core` module aims to have minimal dependencies. It does not require any third-party (non-Micrometer) dependencies on the classpath at compile time for applications using Micrometer.
+
+Use of the link:#_pause_detection[pause detection] feature requires the https://github.com/LatencyUtils/LatencyUtils:[LatencyUtils] dependency to be available on the classpath at runtime. If your application does not use the pause detection feature, you can exclude LatencyUtils from your runtime classpath.
+
+https://github.com/HdrHistogram/HdrHistogram:[HdrHistogram] is needed on the classpath at runtime if you use link:#_histograms_and_percentiles[client-side percentiles]. If you are not using client-side percentiles, you may exclude HdrHistogram from your application's runtime classpath.
+
 == Supported Monitoring Systems
 
 include::implementations.adoc[leveloffset=+1]


### PR DESCRIPTION
Explains when which runtime dependencies are needed or not.

Related to https://github.com/micrometer-metrics/micrometer/pull/3263, https://github.com/micrometer-metrics/micrometer/pull/3325, https://github.com/micrometer-metrics/micrometer/issues/1599, https://github.com/micrometer-metrics/micrometer/issues/3287#issuecomment-1199618538

Closes #240