### PR TITLE
Update micrometer 2.0.0 reference to 1.10.0

### DIFF
--- a/src/docs/concepts/index.adoc
+++ b/src/docs/concepts/index.adoc
@@ -8,7 +8,7 @@ Jon Schneider <jschneider@pivotal.io>
 
 Micrometer is a metrics instrumentation library for JVM-based applications. It provides a simple facade over the instrumentation clients for the most popular monitoring systems, letting you instrument your JVM-based application code without vendor lock-in. It is designed to add little to no overhead to your metrics collection activity while maximizing the portability of your metrics effort.
 
-Micrometer is _not_ a distributed tracing system or an event logger. In Micrometer 2.0, we do however provide a plugin mechanism that allows you to add capabilities including the tracing features. You can read more about this in the link:../docs/tracing[Micrometer Tracing documentation].
+Micrometer is _not_ a distributed tracing system or an event logger. In Micrometer 1.10, we do however provide a plugin mechanism that allows you to add capabilities including the tracing features. You can read more about this in the link:../docs/tracing[Micrometer Tracing documentation].
 
 For better understanding the differences among these different types of systems (Metrics, Distributed Tracing, and Logging) we recommend Adrian Cole's talk, titled https://www.dotconferences.com/2017/04/adrian-cole-observability-3-ways-logging-metrics-tracing[Observability
 3 Ways].


### PR DESCRIPTION
The Micrometer 2.0.0 was replaced with 1.10.0. This change updates
the introduction in concepts to reflect the change