### PR TITLE
Configure Dependabot to monitor Gradle plugin updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,21 @@
 version: 2
+registries:
+  gradle-plugin-portal:
+    type: maven-repository
+    url: https://plugins.gradle.org/m2
+    username: dummy # Required by dependabot
+    password: dummy # Required by dependabot
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    allow:
+      - dependency-name: "com.gradle*"
+    registries:
+      - gradle-plugin-portal
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This PR configures Dependabot to monitor Gradle plugin updates.

See https://github.com/micrometer-metrics/micrometer/pull/3237