### PR TITLE
Added Micrometer's New Relic Integration IO quickstart link

### DIFF
--- a/src/docs/implementations/new-relic.adoc
+++ b/src/docs/implementations/new-relic.adoc
@@ -3,7 +3,7 @@
 :sectnums:
 :system: new-relic
 
-New Relic offers a dimensional monitoring system product called Insights. It includes a full UI and a query language called NRQL. New Relic Insights operates on a push model. Some features of NRQL assume that Insights receives a distinct event payload for every timing, count, and so on. Micrometer instead ships aggregates at a prescribed interval, letting your app's throughput scale without concern for event propagation to Insights becoming a bottleneck.
+[New Relic](https://newrelic.com/instant-observability/micrometer) offers a dimensional monitoring system product called Insights. It includes a full UI and a query language called NRQL. New Relic Insights operates on a push model. Some features of NRQL assume that Insights receives a distinct event payload for every timing, count, and so on. Micrometer instead ships aggregates at a prescribed interval, letting your app's throughput scale without concern for event propagation to Insights becoming a bottleneck.
 
 NOTE: New Relic provides its own Micrometer `MeterRegistry` implementation based on dimensional metrics.
 It intends to supersede Micrometer's `NewRelicMeterRegistry` (which uses custom events in New Relic), because New Relic's dimensional metrics are a better fit for metrics than custom events.


### PR DESCRIPTION
Hi,

We have many users on our platform who are using Micrometer and would like to instrument it. We’d love to provide a smooth experience for Micrometer users who need to use monitoring solutions, such as New Relic. Please see our documentation [here](https://newrelic.com/instant-observability/micrometer).

Please consider adding a link for your direct users to provide an option for New Relic. For your convenience, we have submitted this PR with our proposed content.

Please feel free to let us know if you have any questions or concerns.

Thank you for your consideration.