### PR TITLE
Fix link to HdrHistogram github

### DIFF
--- a/src/docs/concepts/index.adoc
+++ b/src/docs/concepts/index.adoc
@@ -19,7 +19,7 @@ The `micrometer-core` module aims to have minimal dependencies. It does not requ
 
 Use of the link:#_pause_detection[pause detection] feature requires the https://github.com/LatencyUtils/LatencyUtils[LatencyUtils] dependency to be available on the classpath at runtime. If your application does not use the pause detection feature, you can exclude LatencyUtils from your runtime classpath.
 
-https://github.com/HdrHistogram/HdrHistogram:[HdrHistogram] is needed on the classpath at runtime if you use link:#_histograms_and_percentiles[client-side percentiles]. If you are not using client-side percentiles, you may exclude HdrHistogram from your application's runtime classpath.
+https://github.com/HdrHistogram/HdrHistogram[HdrHistogram] is needed on the classpath at runtime if you use link:#_histograms_and_percentiles[client-side percentiles]. If you are not using client-side percentiles, you may exclude HdrHistogram from your application's runtime classpath.
 
 == Supported Monitoring Systems
 


### PR DESCRIPTION
Just fixing a bad link to https://github.com/HdrHistogram/HdrHistogram 