### PR TITLE
Add a note to use DynatraceConfig.DEFAULT from 1.10 on.

### DIFF
--- a/src/docs/implementations/dynatrace.adoc
+++ b/src/docs/implementations/dynatrace.adoc
@@ -41,8 +41,7 @@ If you are using Micrometer 1.10.0 or above, you can also use the DEFAULT config
 
 [source,java]
 ----
-DynatraceConfig dynatraceConfig = DynatraceConfig.DEFAULT;
-MeterRegistry registry = new DynatraceMeterRegistry(dynatraceConfig, Clock.SYSTEM);
+MeterRegistry registry = new DynatraceMeterRegistry(DynatraceConfig.DEFAULT, Clock.SYSTEM);
 ----
 
 It is also possible to change other properties by creating an instance of the `DynatraceConfig` and overwriting the respective methods.

--- a/src/docs/implementations/dynatrace.adoc
+++ b/src/docs/implementations/dynatrace.adoc
@@ -37,7 +37,16 @@ DynatraceConfig dynatraceConfig = new DynatraceConfig() {
 MeterRegistry registry = new DynatraceMeterRegistry(dynatraceConfig, Clock.SYSTEM);
 ----
 
-It is also possible to specify the exporter version explicitly, which defaults to `v2` unless a deviceId is set:
+If you are using Micrometer 1.10.0 or above, you can also use the DEFAULT config to achieve the same with less code:
+
+[source,java]
+----
+DynatraceConfig dynatraceConfig = DynatraceConfig.DEFAULT;
+MeterRegistry registry = new DynatraceMeterRegistry(dynatraceConfig, Clock.SYSTEM);
+----
+
+It is also possible to change other properties by creating an instance of the `DynatraceConfig` and overwriting the respective methods.
+For example, you can specify the exporter version, which defaults to `v2` unless a deviceId is set:
 
 [source,java]
 ----


### PR DESCRIPTION
This PR adds information about the DynatraceConfig.DEFAULT that was added in Micrometer 1.10.