### PR TITLE
Use random port in ObservationInstrumentingTests.should_instrument_http_server()

### DIFF
--- a/samples/src/test/java/io/micrometer/docs/observation/ObservationInstrumentingTests.java
+++ b/samples/src/test/java/io/micrometer/docs/observation/ObservationInstrumentingTests.java
@@ -291,7 +291,7 @@ class ObservationInstrumentingTests {
             // After sending the response we want to stop the Observation
             Observation observation = ctx.attribute(ObservationThreadLocalAccessor.KEY);
             observation.stop();
-        }).start()) {
+        }).start(0)) {
             // We're sending an HTTP request with a <foo:bar> header. We're expecting that
             // it will be reused in the response
             String response = sendRequestToHelloEndpointWithHeader(javalin.port(), "foo", "bar");


### PR DESCRIPTION
This PR changes to use a random port in `ObservationInstrumentingTests.should_instrument_http_server()` as the test fails if 8080 is already occupied by another process.