### PR TITLE
Upgrade to io.spring.ge.conventions 0.0.13

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ pluginManagement {
 
 plugins {
     id 'com.gradle.enterprise' version '3.12.1'
-    id 'io.spring.ge.conventions' version '0.0.11'
+    id 'io.spring.ge.conventions' version '0.0.13'
 }
 
 rootProject.name = 'micrometer-docs'


### PR DESCRIPTION
This PR upgrades to `io.spring.ge.conventions` 0.0.13.