### PR TITLE
Replace references to Pivotal

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ To regenerate the adoc files just run `./gradlew generateCoalescedAdocs`.
 -------------------------------------
 _Licensed under [Apache Software License 2.0](https://www.apache.org/licenses/LICENSE-2.0)_
 
-_Sponsored by [Pivotal](https://pivotal.io)_
+_Sponsored by [VMware](https://tanzu.vmware.com/)_

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -4,7 +4,7 @@ export default function Footer() {
   return (
     <div className="bg-dark text-center">
       <div className="col-12" style={{padding: 10, color: 'white'}}>
-        <p>© 2017 - 2023 Pivotal Software, Inc. All Rights Reserved. See <a href="https://www.pivotal.io/terms-of-use">Terms of Use</a> and <a href="https://www.pivotal.io/privacy-policy">Privacy Policy</a>.</p>
+        <p>© 2017 - 2023 VMware, Inc. All Rights Reserved. See <a href="https://www.vmware.com/help/legal.html">Terms of Use</a> and <a href="https://www.vmware.com/help/privacy.html">Privacy Policy</a>.</p>
       </div>
     </div>
   )

--- a/src/docs/concepts/index.adoc
+++ b/src/docs/concepts/index.adoc
@@ -1,5 +1,4 @@
 = Concepts
-Jon Schneider <jschneider@pivotal.io>
 :toc:
 :sectnums:
 :dimensional: true


### PR DESCRIPTION
I'm not sure what the rationale behind https://github.com/spring-projects/spring-boot/issues/33737 is, but it seems to prefer VMware over Pivotal internally, so this PR applies it to this repo.