### PR TITLE
Replace wording from monitoring to observability on root and docs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -41,7 +41,7 @@
         }
       }(window.location))
     </script>
-    <title>Micrometer Application Monitoring</title>
+    <title>Micrometer Application Observability</title>
   </head>
   <body>
     <noscript>

--- a/src/components/DocRoot/index.js
+++ b/src/components/DocRoot/index.js
@@ -9,9 +9,9 @@ export default function DocRoot() {
       <h1>Micrometer Documentation</h1>
 
       <p>
-        Micrometer provides a simple facade over the instrumentation clients for the most popular monitoring systems,
+        Micrometer provides a simple facade over the instrumentation clients for the most popular observability systems,
         allowing you to instrument your JVM-based application code without vendor lock-in. Think SLF4J, but for
-        application metrics! Application metrics recorded by Micrometer are intended to be used to observe, alert, and
+        application observability! Data recorded by Micrometer are intended to be used to observe, alert, and
         react to the current/recent operational state of your environment.
       </p>
 

--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -9,12 +9,12 @@ export default function Home() {
         <div className="container">
           <img src={logoNoTitle} className="img-fluid" alt="" />
           <h1 className="jumbotron-heading mt-3" style={{ color: 'white', background: 'rgba(52, 48, 45, 0.8)' }}>
-            Vendor-neutral application metrics facade
+            Vendor-neutral application observability facade
           </h1>
           <p className="lead" style={{ padding: 8, color: 'white', background: 'rgba(52, 48, 45, 0.8)' }}>Micrometer
-            provides a simple facade over the instrumentation clients for the most popular monitoring systems,
+            provides a simple facade over the instrumentation clients for the most popular observability systems,
             allowing you to instrument your JVM-based application code without vendor lock-in. Think SLF4J, but for
-            metrics.
+            observability.
           </p>
         </div>
       </div>
@@ -36,20 +36,18 @@ export default function Home() {
             <i className="fa fa-4x fa-leaf" aria-hidden="true" />
             <h2>Integrated into Spring</h2>
             <p>Micrometer is the instrumentation library powering
-              the delivery of application metrics from Spring Boot applications.</p>
+              the delivery of application observability from Spring Boot applications.</p>
           </div>
         </div>
         <div className="row justify-content-center" style={{ padding: 30 }}>
           <div className="col-lg-6 col-md-12">
-            <h2>Support for popular monitoring systems</h2>
+            <h2>Support for popular observability systems</h2>
             <p>As an instrumentation facade, Micrometer allows you to instrument your code with dimensional metrics with
-              a
-              vendor-neutral interface and decide on the monitoring system as a last step. Instrumenting your core
-              library
-              code with Micrometer allows the libraries to be included in applications that ship metrics to different
-              backends.</p>
+              a vendor-neutral interface and decide on the observability system as a last step. Instrumenting your core library
+              code with Micrometer allows the libraries to be included in applications that ship data to different backends.
+            </p>
             <p>
-              Contains built-in support for <strong>AppOptics</strong>, <strong>Azure Monitor</strong>, Netflix <strong>Atlas</strong>, <strong>CloudWatch</strong>, <strong>Datadog</strong>, <strong>Dynatrace</strong>, <strong>Elastic</strong>, <strong>Ganglia</strong>, <strong>Graphite</strong>, <strong>Humio</strong>, <strong>Influx/Telegraf</strong>, <strong>JMX</strong>, <strong>KairosDB</strong>, <strong>New Relic</strong>, <strong>Prometheus</strong>, <strong>SignalFx</strong>, Google <strong>Stackdriver</strong>, <strong>StatsD</strong>, and <strong>Wavefront</strong>.
+              Contains built-in support for <strong>AppOptics</strong>, <strong>Azure Monitor</strong>, Netflix <strong>Atlas</strong>, <strong>CloudWatch</strong>, <strong>Datadog</strong>, <strong>Dynatrace</strong>, <strong>Elastic</strong>, <strong>Ganglia</strong>, <strong>Graphite</strong>, <strong>Humio</strong>, <strong>Influx/Telegraf</strong>, <strong>JMX</strong>, <strong>KairosDB</strong>, <strong>New Relic</strong>, <strong>OpenTelemetry</strong>, <strong>Prometheus</strong>, <strong>SignalFx</strong>, Google <strong>Stackdriver</strong>, <strong>StatsD</strong>, and <strong>Wavefront</strong>.
             </p>
           </div>
         </div>

--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -47,7 +47,7 @@ export default function Home() {
               code with Micrometer allows the libraries to be included in applications that ship data to different backends.
             </p>
             <p>
-              Contains built-in support for <strong>AppOptics</strong>, <strong>Azure Monitor</strong>, Netflix <strong>Atlas</strong>, <strong>CloudWatch</strong>, <strong>Datadog</strong>, <strong>Dynatrace</strong>, <strong>Elastic</strong>, <strong>Ganglia</strong>, <strong>Graphite</strong>, <strong>Humio</strong>, <strong>Influx/Telegraf</strong>, <strong>JMX</strong>, <strong>KairosDB</strong>, <strong>New Relic</strong>, <strong>OpenTelemetry</strong>, <strong>Prometheus</strong>, <strong>SignalFx</strong>, Google <strong>Stackdriver</strong>, <strong>StatsD</strong>, and <strong>Wavefront</strong>.
+              Contains built-in support for <strong>AppOptics</strong>, <strong>Azure Monitor</strong>, Netflix <strong>Atlas</strong>, <strong>CloudWatch</strong>, <strong>Datadog</strong>, <strong>Dynatrace</strong>, <strong>Elastic</strong>, <strong>Ganglia</strong>, <strong>Graphite</strong>, <strong>Humio</strong>, <strong>Influx/Telegraf</strong>, <strong>JMX</strong>, <strong>KairosDB</strong>, <strong>New Relic</strong>, <strong>OpenTelemetry</strong> Protocol (OTLP), <strong>Prometheus</strong>, <strong>SignalFx</strong>, Google <strong>Stackdriver</strong>, <strong>StatsD</strong>, and <strong>Wavefront</strong>.
             </p>
           </div>
         </div>

--- a/src/img/logo.svg
+++ b/src/img/logo.svg
@@ -40,7 +40,7 @@
      showgrid="false"
      inkscape:zoom="0.70710678"
      inkscape:cx="263.04372"
-     inkscape:cy="143.54268"
+     inkscape:cy="146.3711"
      inkscape:window-x="0"
      inkscape:window-y="25"
      inkscape:window-maximized="1"
@@ -194,7 +194,7 @@
 <text
    xml:space="preserve"
    style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Gill Sans';-inkscape-font-specification:'Gill Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-   x="702.5813"
+   x="680.18164"
    y="-339.41125"
    id="text4235"
    transform="scale(1,-1)"
@@ -202,7 +202,7 @@
    inkscape:export-ydpi="69.889999"><tspan
      sodipodi:role="line"
      id="tspan4237"
-     x="702.5813"
+     x="680.18164"
      y="-339.41125"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Gill Sans';-inkscape-font-specification:'Gill Sans';fill:#ffffff">application monitoring</tspan></text>
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Gill Sans';-inkscape-font-specification:'Gill Sans';fill:#ffffff">application observability</tspan></text>
 </g></g></svg>


### PR DESCRIPTION
Since we added the [Observation API](https://micrometer.io/docs/observation) in Micrometer 1.10 and at the same time we released [Micrometer Tracing](https://micrometer.io/docs/tracing), the project now has more capabilities than recording Metrics, you can use it to instrument your components and emit multiple observability signals (metrics, tracing, logging, audit events, etc).

This change makes the wording of the docs site more clear and open about this so that people can see that Micrometer can be used not only for metrics but for other observability needs too.