### PR TITLE
Fix a broken link to Grafana dashboard for Prometheus

### DIFF
--- a/src/docs/implementations/prometheus.adoc
+++ b/src/docs/implementations/prometheus.adoc
@@ -85,7 +85,7 @@ See the https://prometheus.io/docs/querying/basics[Prometheus docs] for a far mo
 
 === Grafana Dashboard
 
-A publicly available Grafana dashboard for Micrometer-sourced JVM and Tomcat metrics is available https://grafana.com/dashboards/4701[here].
+A publicly available Grafana dashboard for Micrometer-sourced JVM and Tomcat metrics is available https://grafana.com/grafana/dashboards/4701-jvm-micrometer/[here].
 
 image::img/prometheus-dashboard.png[Grafana dashboard for JVM and Tomcat binders]
 


### PR DESCRIPTION
This PR fixes a broken link to Grafana dashboard for Prometheus.

See https://github.com/micrometer-metrics/micrometer/issues/3707