### PR TITLE
Add docs for OTLP meter registry.

### DIFF
--- a/src/components/DocRoot/index.js
+++ b/src/components/DocRoot/index.js
@@ -103,7 +103,7 @@ export default function DocRoot() {
               New Relic Insights operates on a push model.
             </li>
 
-            <li><NavLink className="doc-section" to="/docs/registry/otlp">OpenTelemetry</NavLink>.
+            <li><NavLink className="doc-section" to="/docs/registry/otlp">OpenTelemetry (OTLP)</NavLink>.
                OpenTelemetry is a CNCF incubating project for providing standards for open observability. Micrometer publishes metrics in OpenTelemetry protocol using OpenTelemetry SDK.
             </li>
 

--- a/src/components/DocRoot/index.js
+++ b/src/components/DocRoot/index.js
@@ -103,6 +103,10 @@ export default function DocRoot() {
               New Relic Insights operates on a push model.
             </li>
 
+            <li><NavLink className="doc-section" to="/docs/registry/otlp">OpenTelemetry</NavLink>.
+               OpenTelemetry is a CNCF incubating project for providing standards for open observability. Micrometer publishes metrics in OpenTelemetry protocol using OpenTelemetry SDK.
+            </li>
+
             <li><NavLink className="doc-section" to="/docs/registry/prometheus">Prometheus</NavLink>.
               An in-memory dimensional time series database with a simple built-in UI, a custom query language, and math
               operations. Prometheus is designed to operate on a pull model, scraping metrics from application instances

--- a/src/components/DocRoot/index.js
+++ b/src/components/DocRoot/index.js
@@ -103,7 +103,7 @@ export default function DocRoot() {
               New Relic Insights operates on a push model.
             </li>
 
-            <li><NavLink className="doc-section" to="/docs/registry/otlp">OpenTelemetry (OTLP)</NavLink>.
+            <li><NavLink className="doc-section" to="/docs/registry/otlp">OpenTelemetry Protocol (OTLP)</NavLink>.
                OpenTelemetry is a CNCF incubating project for providing standards for telemetry data. Micrometer can publish metrics using the OpenTelemetry protocol (OTLP) to the backends that support it.
             </li>
 

--- a/src/components/DocRoot/index.js
+++ b/src/components/DocRoot/index.js
@@ -104,7 +104,7 @@ export default function DocRoot() {
             </li>
 
             <li><NavLink className="doc-section" to="/docs/registry/otlp">OpenTelemetry (OTLP)</NavLink>.
-               OpenTelemetry is a CNCF incubating project for providing standards for open observability. Micrometer publishes metrics in OpenTelemetry protocol using OpenTelemetry SDK.
+               OpenTelemetry is a CNCF incubating project for providing standards for telemetry data. Micrometer can publish metrics using the OpenTelemetry protocol (OTLP) to the backends that support it.
             </li>
 
             <li><NavLink className="doc-section" to="/docs/registry/prometheus">Prometheus</NavLink>.

--- a/src/components/DocRoutes/index.js
+++ b/src/components/DocRoutes/index.js
@@ -20,7 +20,7 @@ let docsObservation = require('!asciidoc-loader!../../generated-docs/observation
 let docsTracing = require('!asciidoc-loader!../../generated-docs/tracing/index.adoc');
 let docsContextPropagation = require('!asciidoc-loader!../../generated-docs/contextpropagation/index.adoc');
 
-const systems = ['appOptics', 'atlas', 'azure-monitor', 'cloudwatch', 'datadog', 'dynatrace', 'elastic', 'ganglia', 'graphite', 'humio', 'influx', 'instana', 'jmx', 'kairos', 'new-relic', 'prometheus', 'signalFx', 'stackdriver', 'statsD', 'wavefront'];
+const systems = ['appOptics', 'atlas', 'azure-monitor', 'cloudwatch', 'datadog', 'dynatrace', 'elastic', 'ganglia', 'graphite', 'humio', 'influx', 'instana', 'jmx', 'kairos', 'new-relic', 'otlp', 'prometheus', 'signalFx', 'stackdriver', 'statsD', 'wavefront'];
 
 let docsBySystem = {};
 systems.forEach(sys => docsBySystem[sys] = require(`!asciidoc-loader!../../generated-docs/implementations/${sys}.adoc`));

--- a/src/docs/implementations/otlp.adoc
+++ b/src/docs/implementations/otlp.adoc
@@ -74,11 +74,11 @@ The below table maps OTLP datapoint and the micrometer meters,
 |===
 |OTLP DataPoint | Micrometer meter type
 
+|Sums
 |Counter, FunctionCounter
-| Sums
 
 |Gauge
-|Gauge
+|Gauge, TimeGauge, MultiGauge
 
 |Histogram
 |Timer, DistributionSummary, LongTaskTimer, FunctionTimer (only sum and count are set)
@@ -87,7 +87,10 @@ The below table maps OTLP datapoint and the micrometer meters,
 |Timer, DistributionSummary, LongTaskTimer
 |===
 
-*Note*: `max` on Histogram datapoint is only supported in Delta Aggregation Temporality. This is because the values represented by Cumulative min and max will stabilize as more events are recorded and are less useful when recorded over application's lifecycle.
+*Note*:
+
+1. `max` on Histogram datapoint is only supported in Delta Aggregation Temporality. This is because the values represented by Cumulative min and max will stabilize as more events are recorded and are less useful when recorded over application's lifecycle.
+2. Currently, micrometer only export metadata for type `Meter` to OTLP.
 
 == Histograms and Percentiles
 Micrometer `Timer` and `DistributionSummary` supports configuring docs/concepts#_histograms_and_percentiles[client side percentiles and percentile histograms]. OTLP specification terms Summary Data-point (client-side percentiles) as legacy and not recommended for new applications. Summary data point also cannot have min/max associated with it. Due these reasons micrometer prefers exporting Timers and DistributionSummary as Histogram datapoint. By default a Timer/DistributionSummary without any additional percentile/histogram config will be exported as Histogram Datapoint. However, by configuring the timer to generate only client side percentiles using `publishPercentiles` this can be changed to a Summary data point exporting pre-calculated percentiles. When both `publishPercentiles` and (`publishPercentileHistogram` or `serviceLevelObjectives`) are configured Histogram Datapoint is preferred and pre-calculated percentiles *will not* be generated. See the below table on which data point will be used with different configurations:

--- a/src/docs/implementations/otlp.adoc
+++ b/src/docs/implementations/otlp.adoc
@@ -1,0 +1,131 @@
+= Micrometer OTLP
+:toc:
+:sectnums:
+:system: otlp
+
+https://opentelemetry.io/[OpenTelemetry] is a CNCF incubating project. It is a collection of tools, APIs, and SDKs to instrument, generate, collect, and export telemetry data (metrics, logs, and traces). OTLP is a vendor neutral protocol and can be used to send data to multiple back-ends which supports OTLP protocol. Please read the corresponding docs on how the metrics are ingested and can be visualized in the respective vendor docs.
+
+include::install.adoc[]
+
+== Configuring
+The following example configures an OTLP registry:
+
+[source,java]
+----
+OtlpConfig otlpConfig = new OtlpConfig() {
+            @Override
+            public String get(final String key) {
+                return null;
+            }
+};
+
+MeterRegistry registry = new OtlpMeterRegistry(otlpConfig, Clock.SYSTEM);
+----
+
+`OtlpConfig` is an interface with a set of default methods. If, in the implementation of `get(String k)`, rather than returning `null`, you instead bind it to a property source, you can override the default configuration through properties. For example, Micrometer's Spring Boot support binds properties prefixed with `management.otlp.metrics.export` directly to the `OtlpConfig`:
+
+[source, yaml]
+----
+management:
+  otlp:
+    metrics:
+      export:
+        # Supported configs
+        url: "https://otlp.example.com:4318/v1/metrics"
+        aggregationTemporality: "cumulative"
+        headers: "header1=value1"
+        resourceAttributes: "key=value"
+----
+
+1. url - The URL to which data will be reported. Defaults to `http://localhost:4318/v1/metrics`
+2. aggregationTemporality - https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality[Aggregation temporality] determines how the additive quantities are expressed, in relation to time. The supported values are `cumulative` or `delta`. Defaults to `cumulative`. +
+*Note*: This config is introduced in version 1.11.0.
+3. headers - Additional headers to send with exported metrics. This can be used for authorization headers. By default, headers will be loaded from the config. If that is not set, they will be taken from the environment variables `OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_EXPORTER_OTLP_METRICS_HEADERS`. If a header is set in both the environmental variables, the header in the latter will overwrite the former.
+4. resourceAttributes - https://opentelemetry.io/docs/specs/otel/resource/semantic_conventions/#service[Resource attributes] that will be used for all metrics published. By default micrometer adds the following resources,
+[%autowidth]
+|===
+|Key | Default value
+
+|telemetry.sdk.name
+|io.micrometer
+
+|telemetry.sdk.language
+|java
+
+|telemetry.sdk.version
+|<micrometer-core-version> (E.g: 1.11.0)
+
+|service.name
+|unknown_service
+|===
+
+If this config is empty, then resource attributes will be loaded from the environmental variable `OTEL_RESOURCE_ATTRIBUTES`. `service.name` can be overridden by the environmental variable `OTEL_SERVICE_NAME` and this takes precedence over other configs.
+
+== Supported metrics
+https://opentelemetry.io/docs/specs/otel/metrics/data-model/#metric-points[Metric points] define the different data-points that are supported in OTLP. Micrometer supports exporting the below data-points in OTLP format,
+
+1. https://opentelemetry.io/docs/specs/otel/metrics/data-model/#sums[Sums]
+2. https://opentelemetry.io/docs/specs/otel/metrics/data-model/#gauge[Gauge]
+3. https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram[Histogram]
+4. https://opentelemetry.io/docs/specs/otel/metrics/data-model/#summary-legacy[Summary]
+
+The below table maps OTLP datapoint and the micrometer meters,
+[%autowidth]
+|===
+|OTLP DataPoint | Micrometer meter type
+
+|Counter, FunctionCounter
+| Sums
+
+|Gauge
+|Gauge
+
+|Histogram
+|Timer, DistributionSummary, LongTaskTimer, FunctionTimer (only sum and count are set)
+
+|Summary
+|Timer, DistributionSummary, LongTaskTimer
+|===
+
+*Note*: `max` on Histogram datapoint is only supported in Delta Aggregation Temporality.
+
+== Histograms and Percentiles
+Micrometer `Timer` and `DistributionSummary` supports configuring http://localhost:3000/docs/concepts#_histograms_and_percentiles[client side percentiles and percentile histogram]. OTLP specification terms Summary Data-point (client-side percentiles) as legacy and not recommended for new applications. Summary data point also cannot have min/max associated with it. Due these reasons micrometer prefers exporting Timers and DistributionSummary as Histogram datapoint. By default a Timer/DistributionSummary without any additional percentile/histogram config will be exported as Histogram Datapoint. However, by configuring the timer to generate only client side percentiles using `publishPercentiles` this can be changed to a Summary data point exporting pre-calculated percentiles. When both `publishPercentiles` and (`publishPercentileHistogram` or `serviceLevelObjectives`) are configured Histogram Datapoint is preferred and pre-calculated percentiles *will not* be generated. See the below table on which data point will be used with different configurations,
+[%autowidth]
+|===
+|Configuration | OTLP Data point
+
+| publishPercentiles
+| Summary
+
+| publishPercentileHistogram
+| Histogram
+
+| serviceLevelObjectives
+| Histogram
+
+| publishPercentiles and (publishPercentileHistogram/serviceLevelObjectives)
+| Histogram
+|===
+
+Alternatively, If you are using spring boot you can use the https://docs.spring.io/spring-boot/docs/3.1.0/reference/htmlsingle/#actuator.metrics.customizing.per-meter-properties[per meter properties] to configure this behaviour.
+
+If you want to generate Histogram Data point for a timer with name `test.timer` with default buckets generated by micrometer use,
+
+[source.properties]
+----
+management.metrics.distribution.percentiles-histogram.test.timer=true
+----
+
+and for buckets with customized slo,
+[source.properties]
+----
+management.metrics.distribution.slo.test.timer=10.0,100.0,500.0,1000.0
+----
+
+Alternatively, if you want to generate Summary Data point for a timer with name `test.timer` with 90th and 99th percentiles you can use the below config,
+
+[source,properties]
+----
+management.metrics.distribution.percentiles.test.timer=0.9,0.99
+----

--- a/src/docs/implementations/otlp.adoc
+++ b/src/docs/implementations/otlp.adoc
@@ -3,7 +3,7 @@
 :sectnums:
 :system: otlp
 
-https://opentelemetry.io/[OpenTelemetry] is a CNCF incubating project. It is a collection of tools, APIs, and SDKs to instrument, generate, collect, and export telemetry data (metrics, logs, and traces). OTLP is a vendor neutral protocol and can be used to send data to multiple back-ends which supports OTLP protocol. Please read the corresponding docs on how the metrics are ingested and can be visualized in the respective vendor docs.
+OpenTelemetry is a CNCF incubating project for providing standards for telemetry data. OpenTelemetry protocol (OTLP) is a vendor neutral protocol that can be used to send data to various back-ends which supports it. You can read the corresponding docs on how the metrics are ingested and can be visualized in the respective vendor docs.
 
 include::install.adoc[]
 
@@ -22,7 +22,7 @@ OtlpConfig otlpConfig = new OtlpConfig() {
 MeterRegistry registry = new OtlpMeterRegistry(otlpConfig, Clock.SYSTEM);
 ----
 
-`OtlpConfig` is an interface with a set of default methods. If, in the implementation of `get(String k)`, rather than returning `null`, you instead bind it to a property source, you can override the default configuration through properties. For example, Micrometer's Spring Boot support binds properties prefixed with `management.otlp.metrics.export` directly to the `OtlpConfig`:
+`OtlpConfig` is an interface with a set of default methods. If, in the implementation of `get(String k)`, rather than returning `null`, you instead bind it to a property source (e.g.: a simple `Map` can work), you can override the default configuration through properties. For example, Micrometer's Spring Boot support binds properties prefixed with `management.otlp.metrics.export` directly to the `OtlpConfig`:
 
 [source, yaml]
 ----
@@ -39,8 +39,8 @@ management:
 
 1. url - The URL to which data will be reported. Defaults to `http://localhost:4318/v1/metrics`
 2. aggregationTemporality - https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality[Aggregation temporality] determines how the additive quantities are expressed, in relation to time. The supported values are `cumulative` or `delta`. Defaults to `cumulative`. +
-*Note*: This config is introduced in version 1.11.0.
-3. headers - Additional headers to send with exported metrics. This can be used for authorization headers. By default, headers will be loaded from the config. If that is not set, they will be taken from the environment variables `OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_EXPORTER_OTLP_METRICS_HEADERS`. If a header is set in both the environmental variables, the header in the latter will overwrite the former.
+*Note*: This config was introduced in version 1.11.0.
+3. headers - Additional headers to send with exported metrics. This can be used for authorization headers. By default, headers will be loaded from the config. If that is not set, they can be taken from the environment variables `OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_EXPORTER_OTLP_METRICS_HEADERS`. If a header is set in both the environmental variables, the header in the latter will overwrite the former.
 4. resourceAttributes - https://opentelemetry.io/docs/specs/otel/resource/semantic_conventions/#service[Resource attributes] that will be used for all metrics published. By default micrometer adds the following resources,
 [%autowidth]
 |===
@@ -53,7 +53,7 @@ management:
 |java
 
 |telemetry.sdk.version
-|<micrometer-core-version> (E.g: 1.11.0)
+|<micrometer-core-version> (e.g.: 1.11.0)
 
 |service.name
 |unknown_service
@@ -87,10 +87,10 @@ The below table maps OTLP datapoint and the micrometer meters,
 |Timer, DistributionSummary, LongTaskTimer
 |===
 
-*Note*: `max` on Histogram datapoint is only supported in Delta Aggregation Temporality.
+*Note*: `max` on Histogram datapoint is only supported in Delta Aggregation Temporality. This is because the values represented by Cumulative min and max will stabilize as more events are recorded and are less useful when recorded over application's lifecycle.
 
 == Histograms and Percentiles
-Micrometer `Timer` and `DistributionSummary` supports configuring http://localhost:3000/docs/concepts#_histograms_and_percentiles[client side percentiles and percentile histogram]. OTLP specification terms Summary Data-point (client-side percentiles) as legacy and not recommended for new applications. Summary data point also cannot have min/max associated with it. Due these reasons micrometer prefers exporting Timers and DistributionSummary as Histogram datapoint. By default a Timer/DistributionSummary without any additional percentile/histogram config will be exported as Histogram Datapoint. However, by configuring the timer to generate only client side percentiles using `publishPercentiles` this can be changed to a Summary data point exporting pre-calculated percentiles. When both `publishPercentiles` and (`publishPercentileHistogram` or `serviceLevelObjectives`) are configured Histogram Datapoint is preferred and pre-calculated percentiles *will not* be generated. See the below table on which data point will be used with different configurations,
+Micrometer `Timer` and `DistributionSummary` supports configuring docs/concepts#_histograms_and_percentiles[client side percentiles and percentile histograms]. OTLP specification terms Summary Data-point (client-side percentiles) as legacy and not recommended for new applications. Summary data point also cannot have min/max associated with it. Due these reasons micrometer prefers exporting Timers and DistributionSummary as Histogram datapoint. By default a Timer/DistributionSummary without any additional percentile/histogram config will be exported as Histogram Datapoint. However, by configuring the timer to generate only client side percentiles using `publishPercentiles` this can be changed to a Summary data point exporting pre-calculated percentiles. When both `publishPercentiles` and (`publishPercentileHistogram` or `serviceLevelObjectives`) are configured Histogram Datapoint is preferred and pre-calculated percentiles *will not* be generated. See the below table on which data point will be used with different configurations:
 [%autowidth]
 |===
 |Configuration | OTLP Data point
@@ -108,22 +108,22 @@ Micrometer `Timer` and `DistributionSummary` supports configuring http://localho
 | Histogram
 |===
 
-Alternatively, If you are using spring boot you can use the https://docs.spring.io/spring-boot/docs/3.1.0/reference/htmlsingle/#actuator.metrics.customizing.per-meter-properties[per meter properties] to configure this behaviour.
+Alternatively, If you are using Spring Boot you can use the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#actuator.metrics.customizing.per-meter-properties[per meter properties] to configure this behaviour.
 
-If you want to generate Histogram Data point for a timer with name `test.timer` with default buckets generated by micrometer use,
+If you want to generate Histogram Data point for a Timer with name `test.timer` with default buckets generated by micrometer use:
 
 [source.properties]
 ----
 management.metrics.distribution.percentiles-histogram.test.timer=true
 ----
 
-and for buckets with customized slo,
+and for buckets with customized slo:
 [source.properties]
 ----
 management.metrics.distribution.slo.test.timer=10.0,100.0,500.0,1000.0
 ----
 
-Alternatively, if you want to generate Summary Data point for a timer with name `test.timer` with 90th and 99th percentiles you can use the below config,
+Alternatively, if you want to generate Summary Data point for a timer with name `test.timer` with 90th and 99th percentiles you can use the below config:
 
 [source,properties]
 ----


### PR DESCRIPTION
resolves https://github.com/micrometer-metrics/micrometer-docs/issues/267,

Initial docs about OTLP Meter registry.

Please feel free to add additional commits to this PR.