### PR TITLE
Polish "Add docs for OTLP meter registry"

### DIFF
--- a/src/docs/implementations/otlp.adoc
+++ b/src/docs/implementations/otlp.adoc
@@ -38,10 +38,10 @@ management:
 ----
 
 1. url - The URL to which data will be reported. Defaults to `http://localhost:4318/v1/metrics`
-2. aggregationTemporality - https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality[Aggregation temporality] determines how the additive quantities are expressed, in relation to time. The supported values are `cumulative` or `delta`. Defaults to `cumulative`. +
+2. aggregationTemporality - https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality[Aggregation temporality, window=_blank] determines how the additive quantities are expressed, in relation to time. The supported values are `cumulative` or `delta`. Defaults to `cumulative`. +
 *Note*: This config was introduced in version 1.11.0.
 3. headers - Additional headers to send with exported metrics. This can be used for authorization headers. By default, headers will be loaded from the config. If that is not set, they can be taken from the environment variables `OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_EXPORTER_OTLP_METRICS_HEADERS`. If a header is set in both the environmental variables, the header in the latter will overwrite the former.
-4. resourceAttributes - https://opentelemetry.io/docs/specs/otel/resource/semantic_conventions/#service[Resource attributes] that will be used for all metrics published. By default micrometer adds the following resources,
+4. resourceAttributes - https://opentelemetry.io/docs/specs/otel/resource/semantic_conventions/#service[Resource attributes, window=_blank] that will be used for all metrics published. By default micrometer adds the following resources,
 [%autowidth]
 |===
 |Key | Default value
@@ -62,12 +62,12 @@ management:
 If this config is empty, then resource attributes will be loaded from the environmental variable `OTEL_RESOURCE_ATTRIBUTES`. `service.name` can be overridden by the environmental variable `OTEL_SERVICE_NAME` and this takes precedence over other configs.
 
 == Supported metrics
-https://opentelemetry.io/docs/specs/otel/metrics/data-model/#metric-points[Metric points] define the different data-points that are supported in OTLP. Micrometer supports exporting the below data-points in OTLP format,
+https://opentelemetry.io/docs/specs/otel/metrics/data-model/#metric-points[Metric points, window=_blank] define the different data-points that are supported in OTLP. Micrometer supports exporting the below data-points in OTLP format,
 
-1. https://opentelemetry.io/docs/specs/otel/metrics/data-model/#sums[Sums]
-2. https://opentelemetry.io/docs/specs/otel/metrics/data-model/#gauge[Gauge]
-3. https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram[Histogram]
-4. https://opentelemetry.io/docs/specs/otel/metrics/data-model/#summary-legacy[Summary]
+1. https://opentelemetry.io/docs/specs/otel/metrics/data-model/#sums[Sums, window=_blank]
+2. https://opentelemetry.io/docs/specs/otel/metrics/data-model/#gauge[Gauge, window=_blank]
+3. https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram[Histogram, window=_blank]
+4. https://opentelemetry.io/docs/specs/otel/metrics/data-model/#summary-legacy[Summary, window=_blank]
 
 The below table maps OTLP datapoint and the micrometer meters,
 [%autowidth]
@@ -93,7 +93,7 @@ The below table maps OTLP datapoint and the micrometer meters,
 2. Currently, micrometer only export metadata for type `Meter` to OTLP.
 
 == Histograms and Percentiles
-Micrometer `Timer` and `DistributionSummary` supports configuring docs/concepts#_histograms_and_percentiles[client side percentiles and percentile histograms]. OTLP specification terms Summary Data-point (client-side percentiles) as legacy and not recommended for new applications. Summary data point also cannot have min/max associated with it. Due these reasons micrometer prefers exporting Timers and DistributionSummary as Histogram datapoint. By default a Timer/DistributionSummary without any additional percentile/histogram config will be exported as Histogram Datapoint. However, by configuring the timer to generate only client side percentiles using `publishPercentiles` this can be changed to a Summary data point exporting pre-calculated percentiles. When both `publishPercentiles` and (`publishPercentileHistogram` or `serviceLevelObjectives`) are configured Histogram Datapoint is preferred and pre-calculated percentiles *will not* be generated. See the below table on which data point will be used with different configurations:
+Micrometer `Timer` and `DistributionSummary` supports configuring link:/docs/concepts#_histograms_and_percentiles[client side percentiles and percentile histograms]. OTLP specification terms Summary Data-point (client-side percentiles) as legacy and not recommended for new applications. Summary data point also cannot have min/max associated with it. Due these reasons micrometer prefers exporting Timers and DistributionSummary as Histogram datapoint. By default a Timer/DistributionSummary without any additional percentile/histogram config will be exported as Histogram Datapoint. However, by configuring the timer to generate only client side percentiles using `publishPercentiles` this can be changed to a Summary data point exporting pre-calculated percentiles. When both `publishPercentiles` and (`publishPercentileHistogram` or `serviceLevelObjectives`) are configured Histogram Datapoint is preferred and pre-calculated percentiles *will not* be generated. See the below table on which data point will be used with different configurations:
 [%autowidth]
 |===
 |Configuration | OTLP Data point
@@ -111,7 +111,7 @@ Micrometer `Timer` and `DistributionSummary` supports configuring docs/concepts#
 | Histogram
 |===
 
-Alternatively, If you are using Spring Boot you can use the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#actuator.metrics.customizing.per-meter-properties[per meter properties] to configure this behaviour.
+Alternatively, If you are using Spring Boot you can use the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#actuator.metrics.customizing.per-meter-properties[per meter properties, window=_blank] to configure this behaviour.
 
 If you want to generate Histogram Data point for a Timer with name `test.timer` with default buckets generated by micrometer use:
 


### PR DESCRIPTION
polishes https://github.com/micrometer-metrics/micrometer-docs/pull/308,
- Fix a broken link to the Histogram section from OTLP
- force a new tab for external links in OTLP
