### PR TITLE
Describe prefix changes in Spring Boot 3

### DIFF
--- a/src/docs/implementations/dynatrace.adoc
+++ b/src/docs/implementations/dynatrace.adoc
@@ -65,8 +65,11 @@ MeterRegistry registry = new DynatraceMeterRegistry(dynatraceConfig, Clock.SYSTE
 ----
 
 `DynatraceConfig` is an interface with a set of default methods.
-Spring Boot's Micrometer support binds properties prefixed with `management.metrics.export.dynatrace` directly to the `DynatraceConfig`.
-This allows configuring the Dynatrace exporter by using <<bookmark-available-properties, the available properties>>.
+Spring Boot's Micrometer support binds properties prefixed with `management.dynatrace.metrics.export` directly to the `DynatraceConfig`.
+
+NOTE: Property names for binding attributes from Spring Boot have changed in Spring Boot version 3.0.0. If you use a Spring Boot version before 3.0.0, use `management.metrics.export.dynatrace` instead of `management.dynatrace.metrics.export`. 
+
+Using Spring Boot Micrometer support allows configuring the Dynatrace exporter by using <<bookmark-available-properties, the available properties>>.
 When using Micrometer with Spring Boot, you don't have to instantiate the `DynatraceMeterRegistry` manually as Spring Boot will do it automatically for you.
 All configuration options that can be set by overwriting methods can also be set via Spring Boot properties, and adding a separate MeterRegistry can lead to metrics not being exported as auto-configuration might break.
 
@@ -114,13 +117,16 @@ MeterRegistry registry = new DynatraceMeterRegistry(dynatraceConfig, Clock.SYSTE
 ----
 
 These properties can also be set via Spring Boot, using property or yaml files.
-It is also possible to reference environment variables using the Spring property placeholders (e.g.: `management.metrics.export.dynatrace.uri: ${DT_METRICS_INGEST_URL}`).
+It is also possible to reference environment variables using the Spring property placeholders (e.g.: `management.dynatrace.metrics.export.uri: ${DT_METRICS_INGEST_URL}`).
 
 NOTE: `v2` is used as the default API version unless a `deviceId` is set (<<bookmark-apiv1, see below>>).
 
 [source,yml]
 ----
-management.metrics.export.dynatrace:
+# For Spring Boot 3.0.0 and above:
+management.dynatrace.metrics.export:
+# For Spring Boot versions below 3.0.0, use the line below instead of the line above:
+# management.metrics.export.dynatrace:
     # for SaaS: https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest
     # for managed deployments: https://{your-domain}/e/{your-environment-id}/api/v2/metrics/ingest
     uri: YOUR_METRICS_INGEST_URL
@@ -219,7 +225,7 @@ These properties can also be set in Spring Boot configuration files:
 
 [source,yml]
 ----
-management.metrics.export.dynatrace:
+management.dynatrace.metrics.export:
     # Required only if not using the OneAgent endpoint
     # For SaaS: https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest
     # For managed deployments: https://{your-domain}/e/{your-environment-id}/api/v2/metrics/ingest
@@ -302,7 +308,7 @@ MeterRegistry registry = new DynatraceMeterRegistry(dynatraceConfig, Clock.SYSTE
 
 [source,yml]
 ----
-management.metrics.export.dynatrace:
+management.dynatrace.metrics.export:
     # For v1 export, do not append a path to the endpoint URL, e.g.:
     # For SaaS: https://{your-environment-id}.live.dynatrace.com
     # For managed deployments: https://{your-domain}/e/{your-environment-id}


### PR DESCRIPTION
Default to the Spring Boot 3 way of naming properties (`management.dynatrace.metrics.export` instead of `management.metrics.export.dynatrace`)