### PR TITLE
Clarify MultiGauge usage

### DIFF
--- a/src/docs/concepts/gauges.adoc
+++ b/src/docs/concepts/gauges.adoc
@@ -90,7 +90,7 @@ my_other_gauge_seconds 0.004
 == Multi-gauge
 
 Micrometer supports one last special type of `Gauge`, called a `MultiGauge`, to help manage gauging a growing or shrinking list of criteria.
-This feature lets you select a set of well-bounded but slightly changing set of criteria from something like an SQL query and report some metric for each row as a `Gauge`. The following example creates a `MultiGauge`:
+This feature lets you select a set of well-bounded but slightly changing set of criteria from something like an SQL query and report each row as a `Gauge`. The following example creates a `MultiGauge`:
 
 [source, java]
 ----
@@ -103,10 +103,11 @@ MultiGauge statuses = MultiGauge.builder("statuses")
 
 ...
 
-// run this periodically whenever you re-run your query
+// run this periodically with scrapping frequency
 statuses.register(
     resultSet.stream()
         .map(result -> Row.of(Tags.of("status", result.getAsString("status")), result.getAsInt("count")))
-        .collect(toList())
+        .collect(toList()),
+    true
 );
 ----


### PR DESCRIPTION
Documentation example shows usage MultiGauge for SQL report.

In such context:
- MultiGauge must be update with scrapping frequency
- MultiGauge must overwrite previous report