### PR TITLE
Update links in Dynatrace docs

### DIFF
--- a/src/docs/implementations/dynatrace.adoc
+++ b/src/docs/implementations/dynatrace.adoc
@@ -11,8 +11,8 @@ include::install.adoc[]
 
 == Configuring
 
-For setting up new integrations with Dynatrace, it is recommended to use the latest version of the https://www.dynatrace.com/support/help/dynatrace-api/environment-api/metric-v2/[Dynatrace Metrics API] (v2).
-If you are using Micrometer with Spring Boot, please also refer to the https://www.dynatrace.com/support/help/extend-dynatrace/extend-metrics/ingestion-methods/micrometer/[Dynatrace documentation] and/or the https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.metrics.export.dynatrace[Spring Boot documentation].
+For setting up new integrations with Dynatrace, it is recommended to use the latest version of the https://docs.dynatrace.com/docs/shortlink/api-metrics-v2[Dynatrace Metrics API] (v2).
+If you are using Micrometer with Spring Boot, please also refer to the https://docs.dynatrace.com/docs/shortlink/micrometer-metrics-ingest[Dynatrace documentation] and/or the https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.metrics.export.dynatrace[Spring Boot documentation].
 Dynatrace provides different ways of setting up integrations:
 
 === Using Dynatrace auto-configuration (preferred) [[bookmark-auto-configuration]]
@@ -79,7 +79,7 @@ In this default configuration, metrics will be exported to the local OneAgent or
 === Using a custom endpoint
 
 If auto-configuration is not available on the host, both the Dynatrace Metrics API v2 endpoint and an API token have to be specified.
-The https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication/[Dynatrace API token documentation] contains more information on how to create an API token.
+The https://docs.dynatrace.com/docs/shortlink/api-authentication[Dynatrace API token documentation] contains more information on how to create an API token.
 The 'Ingest metrics' (`metrics.ingest`) permission is required on the token in order to ingest metrics.
 It is recommended to limit scope to only this permission.
 
@@ -140,7 +140,7 @@ management.dynatrace.metrics.export:
 Starting with Micrometer 1.12.0, the Dynatrace registry v2 exports meter metadata to Dynatrace.
 Currently supported types of metadata are *unit* (called "base unit" in Micrometer) and *description*.
 No changes are required to start exporting Metadata to Dynatrace - upgrading to version 1.12.0 or above is enough.
-Find more information about metrics metadata in the https://www.dynatrace.com/support/help/extend-dynatrace/extend-metrics/reference/metric-ingestion-protocol#metadata[Dynatrace documentation].
+Find more information about metrics metadata in the https://docs.dynatrace.com/docs/shortlink/metric-ingestion-protocol#metadata[Dynatrace documentation].
 
 The export of metrics metadata can be disabled by setting the `exportMeterMetadata` property on the `DynatraceConfig` (see <<bookmark-available-properties, the section on available properties>> below) to `false`.
 
@@ -148,7 +148,7 @@ The export of metrics metadata can be disabled by setting the `exportMeterMetada
 
 === API v2 [[bookmark-apiv2]]
 
-When the API version is configured to `v2`, the registry will send data using the https://www.dynatrace.com/support/help/dynatrace-api/environment-api/metric-v2/[Metrics API v2].
+When the API version is configured to `v2`, the registry will send data using the https://docs.dynatrace.com/docs/shortlink/api-metrics-v2[Metrics API v2].
 In order to maintain backwards compatibility, when a `deviceId` is set (which is required for `v1` and not used in `v2`), `v1` is used as the default.
 Otherwise, the version defaults to `v2`, and does not have to be set explicitly.
 With no endpoint URI and token set, metrics will be exported to the local OneAgent endpoint or, if running in Kubernetes with the Dynatrace operator installed, to the endpoint provided by the operator.
@@ -158,21 +158,21 @@ Explicitly specifying these will overwrite auto-configuration.
 *Minimal configuration with Dynatrace auto-configuration*
 
 In the minimal configuration <<bookmark-auto-configuration, shown above>> (no URI or API token), the v2 registry will attempt to retrieve the endpoint provided by the Dynatrace Kubernetes operator.
-If the operator is not set up or does not provide this information, the exporter will attempt to send metrics to the https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/local-api/[local OneAgent metrics ingest endpoint].
-Note that this only works if a OneAgent is running on the host and the https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/local-api/#enable-the-oneagent-metric-api[local OneAgent Metric API] is available.
+If the operator is not set up or does not provide this information, the exporter will attempt to send metrics to the https://docs.dynatrace.com/docs/shortlink/local-api[local OneAgent metrics ingest endpoint].
+Note that this only works if a OneAgent is running on the host and the https://docs.dynatrace.com/docs/shortlink/local-api#enable-the-oneagent-metric-api[local OneAgent Metric API] is available.
 If the ingestion port for the local OneAgent was changed to a custom one, the full endpoint URI has to be provided for the URI property (with API token left empty).
 
 *Configuration with URI and API token*
 
-If no auto-configuration is available or the metrics should be sent to a different endpoint (e.g. a different tenant), the Dynatrace v2 exporter can be configured with an explicit endpoint URI and an https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication/[API token].
-The https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication/[API token] must have the https://www.dynatrace.com/support/help/shortlink/api-authentication#token-permissions["Ingest metrics"] (`metrics.ingest`) permission set.
+If no auto-configuration is available or the metrics should be sent to a different endpoint (e.g. a different tenant), the Dynatrace v2 exporter can be configured with an explicit endpoint URI and an https://docs.dynatrace.com/docs/shortlink/api-authentication[API token].
+The https://docs.dynatrace.com/docs/shortlink/api-authentication[API token] must have the https://docs.dynatrace.com/docs/dynatrace-api/basics/dynatrace-api-authentication#token-scopes["Ingest metrics"] (`metrics.ingest`) permission set.
 It is recommended to limit scope to only this permission.
 
-The entire Metrics v2 API endpoint URI has to be specified including its path, i.e.: with the path `/api/v2/metrics/ingest` on SaaS and managed deployments, or `/metrics/ingest` for OneAgent endpoints as mentioned in the https://www.dynatrace.com/support/help/dynatrace-api/environment-api/metric-v2/post-ingest-metrics/[documentation].
+The entire Metrics v2 API endpoint URI has to be specified including its path, i.e.: with the path `/api/v2/metrics/ingest` on SaaS and managed deployments, or `/metrics/ingest` for OneAgent endpoints as mentioned in the https://docs.dynatrace.com/docs/shortlink/api-metrics-v2-post-datapoints[documentation].
 
 *Properties available in the v2 exporter* [[bookmark-available-properties]]
 
-When using the https://www.dynatrace.com/support/help/dynatrace-api/environment-api/metric-v2/[Dynatrace metrics API v2], the following properties can be set:
+When using the https://docs.dynatrace.com/docs/shortlink/api-metrics-v2[Dynatrace metrics API v2], the following properties can be set:
 
 [source,java]
 ----
@@ -277,7 +277,7 @@ management.dynatrace.metrics.export:
     step: 60s
 ----
 
-For more information about the metadata picked up by the Dynatrace metadata enrichment feature, see https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/enrich-metrics/[the Dynatrace documentation].
+For more information about the metadata picked up by the Dynatrace metadata enrichment feature, see https://docs.dynatrace.com/docs/shortlink/enrichment-files[the Dynatrace documentation].
 
 In Micrometer 1.9.0, Dynatrace-specific summary instruments (`DynatraceTimer` and `DynatraceDistributionSummary`) were introduced.
 These specialized instruments are tailored to the Dynatrace metrics ingest, and prevent the creation of invalid metrics.
@@ -286,11 +286,11 @@ No action is needed from users upgrading to 1.9.0. If there is a discrepancy in 
 
 === API v1 (Legacy) [[bookmark-apiv1]]
 
-When the apiVersion is configured to `v1`, the registry will send data using the https://www.dynatrace.com/support/help/dynatrace-api/environment-api/metric-v1/custom-metrics/[Dynatrace Timeseries API v1 for custom metrics].
+When the apiVersion is configured to `v1`, the registry will send data using the https://docs.dynatrace.com/docs/shortlink/api-custom-metrics[Dynatrace Timeseries API v1 for custom metrics].
 If a `deviceId` is specified, it will default to `v1` for backwards compatibility with earlier setups.
 The `device-id` property is required for `v1` and not used in `v2`.
 Existing setups will continue to work when updating to newer versions of Micrometer.
-The reported metrics will be assigned to https://www.dynatrace.com/support/help/dynatrace-api/environment-api/topology-and-smartscape/custom-device-api/report-custom-device-metric-via-rest-api/[custom devices] in Dynatrace.
+The reported metrics will be assigned to https://docs.dynatrace.com/docs/shortlink/api-custom-device-report-metric[custom devices] in Dynatrace.
 
 For the v1 API, do not specify the ingest path, but only the base URL of your environment, e.g.: `uri: https://{your-environment-id}.live.dynatrace.com`
 


### PR DESCRIPTION
At Dynatrace, the documentation URLs now have an overhauled format, including new shortlinks. This PR swaps out the "old" links with the new style of shortlink in the documentation.